### PR TITLE
Add imago-cli deploy scaffold and ci rust checks

### DIFF
--- a/.github/workflows/ci-rust-checks.yml
+++ b/.github/workflows/ci-rust-checks.yml
@@ -1,0 +1,42 @@
+name: ci-rust-checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-rust-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test --workspace
+
+      - name: cargo check
+        run: cargo check --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,188 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "imago-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "imago-protocol"
 version = "0.1.0"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/crates/imago-cli/Cargo.toml
+++ b/crates/imago-cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "imago-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "imago"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.5.31", features = ["derive"] }

--- a/crates/imago-cli/src/cli.rs
+++ b/crates/imago-cli/src/cli.rs
@@ -1,0 +1,81 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser, PartialEq, Eq)]
+#[command(name = "imago", version, about = "imago CLI")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, PartialEq, Eq)]
+pub enum Commands {
+    Deploy(DeployArgs),
+}
+
+#[derive(Debug, Args, Clone, PartialEq, Eq)]
+pub struct DeployArgs {
+    #[arg(long, value_name = "ENV_NAME")]
+    pub env: Option<String>,
+
+    #[arg(long, value_name = "TARGET_NAME")]
+    pub target: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parses_deploy_without_options() {
+        let cli = Cli::try_parse_from(["imago", "deploy"]).expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                command: Commands::Deploy(DeployArgs {
+                    env: None,
+                    target: None,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_deploy_with_env() {
+        let cli = Cli::try_parse_from(["imago", "deploy", "--env", "prod"])
+            .expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                command: Commands::Deploy(DeployArgs {
+                    env: Some("prod".to_string()),
+                    target: None,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_deploy_with_target() {
+        let cli = Cli::try_parse_from(["imago", "deploy", "--target", "default"])
+            .expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                command: Commands::Deploy(DeployArgs {
+                    env: None,
+                    target: Some("default".to_string()),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_subcommand() {
+        let err = Cli::try_parse_from(["imago", "unknown"]).expect_err("parse should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
+    }
+}

--- a/crates/imago-cli/src/commands/deploy.rs
+++ b/crates/imago-cli/src/commands/deploy.rs
@@ -1,0 +1,41 @@
+use crate::cli::DeployArgs;
+
+pub const NOT_IMPLEMENTED_MESSAGE: &str = "imago deploy is not implemented yet.";
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommandResult {
+    pub exit_code: i32,
+    pub stderr: Option<&'static str>,
+}
+
+pub fn run(_args: DeployArgs) -> CommandResult {
+    CommandResult {
+        exit_code: 2,
+        stderr: Some(NOT_IMPLEMENTED_MESSAGE),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_exit_code_two() {
+        let result = run(DeployArgs {
+            env: None,
+            target: None,
+        });
+
+        assert_eq!(result.exit_code, 2);
+    }
+
+    #[test]
+    fn returns_not_implemented_message() {
+        let result = run(DeployArgs {
+            env: Some("prod".to_string()),
+            target: Some("default".to_string()),
+        });
+
+        assert_eq!(result.stderr, Some(NOT_IMPLEMENTED_MESSAGE));
+    }
+}

--- a/crates/imago-cli/src/main.rs
+++ b/crates/imago-cli/src/main.rs
@@ -1,0 +1,49 @@
+mod cli;
+mod commands {
+    pub mod deploy;
+}
+
+use clap::Parser;
+use cli::{Cli, Commands};
+use commands::deploy::CommandResult;
+
+fn dispatch(cli: Cli) -> CommandResult {
+    match cli.command {
+        Commands::Deploy(args) => commands::deploy::run(args),
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let result = dispatch(cli);
+
+    if let Some(message) = result.stderr {
+        eprintln!("{message}");
+    }
+
+    if result.exit_code != 0 {
+        std::process::exit(result.exit_code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::DeployArgs;
+
+    #[test]
+    fn dispatches_deploy_and_returns_non_zero() {
+        let result = dispatch(Cli {
+            command: Commands::Deploy(DeployArgs {
+                env: None,
+                target: None,
+            }),
+        });
+
+        assert_eq!(result.exit_code, 2);
+        assert_eq!(
+            result.stderr,
+            Some(commands::deploy::NOT_IMPLEMENTED_MESSAGE)
+        );
+    }
+}


### PR DESCRIPTION
Closes #27

Summary
- add the new `imago-cli` crate with a `clap`-derived `imago deploy` command that returns exit code 2 with an unimplemented message
- keep the CLI parsing tests in `cli.rs` and add behavior tests for the deploy command handler and dispatcher
- introduce the `ci-rust-checks` GitHub Actions workflow to run fmt/clippy/test/check on pushes to `main` and pull requests

Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo check --workspace
