### PR TITLE
Bump web-transport-quinn to 0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3747,7 +3747,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4134,7 +4134,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4226,7 +4226,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4845,7 +4845,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6259,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-proto"
-version = "0.5.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1178b54e051ff748f2be77d5f462453c459f921f84cda01ff7f5f3340db60d87"
+checksum = "5afe275c02f899650c5497b946552fcc04f3f378bd2c3bc1e8005ff915772b97"
 dependencies = [
  "bytes",
  "http",
@@ -6273,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2980685bd014e2fa4e99f60c41f2f045827df4cdcda1ac26eb64a8534ef98cb1"
+checksum = "6d356bedff779480f8d88d94bf50a2eb8dedabb84414442f73c16dfee9db55b8"
 dependencies = [
  "bytes",
  "futures",
@@ -6293,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-trait"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2615c30ed29953bb3727391850279a25c948c0b7a4ed2343d3a78e1d3cce2f7c"
+checksum = "802d6aa508f2c63c9050ceabc17265bbf90ed4d6f4e4357e987583883628e79c"
 dependencies = [
  "bytes",
 ]
@@ -6389,7 +6389,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ wasmtime-wasi-http = "41.0.3"
 wat = "1.244.0"
 wit-component = "0.244.0"
 wit-parser = "0.244.0"
-web-transport-quinn = "0.11.1"
+web-transport-quinn = "0.11.6"
 syn = "2.0.111"
 
 imago-plugin-imago-admin = { path = "plugins/imago-admin" }


### PR DESCRIPTION
Summary
- Workspace 依存の `web-transport-quinn` を `0.11.6` に固定し、Cargo.lock も一致させた
- `web-transport-proto`/`web-transport-trait` の依存版もそれに合わせて更新し、関連する windows-sys の解決先も調整した

Testing
- Not run (not requested)