### PR TITLE
Rewrite AGENTS guidance to match workspace reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Scope & Coverage
-This file applies to all paths under `/Users/sizumita/.codex/worktrees/dced/imago`.
+This file applies to all paths in this repository.
 If a deeper `AGENTS.md` exists in a subdirectory, that file overrides this one for its scope.
 
 ## Workspace Reality


### PR DESCRIPTION
## Motivation
- Keep `AGENTS.md` aligned with the actual `imago` workspace shape so contributors do not follow outdated single-crate assumptions.
- Remove conflicting/duplicated PR guidance and make `.github/pull_request_template.md` the single source of truth.

## Summary
- Reorganized `/Users/sizumita/.codex/worktrees/dced/imago/AGENTS.md` into the agreed section order:
  - Scope & Coverage
  - Workspace Reality
  - Cross-cutting Engineering Rules
  - Build/Test Commands
  - Design Change Documentation Policy
  - Commit & PR Rules
  - Testing Guidelines
  - Phase / Issue & Local Operational Rules
- Replaced single-crate wording with workspace-wide reality (`crates/*`, `plugins/*`, `examples/local-imagod*`, `e2e`).
- Unified design-impacting PR requirements and general PR rules around `## Motivation`, `## Summary`, and `## Validation` in `.github/pull_request_template.md`.
- Kept existing project-specific rules, including `docs/spec` sync, `## 実装反映ノート`, Phase 0 issue operation, and sub-agent usage guidance.

## Validation
- Not run (documentation-only change).
- Verified manually that:
  - section order matches the planned structure,
  - conflicting PR-body instructions were removed,
  - template heading requirements are consistent with `.github/pull_request_template.md`.
