### PR TITLE
Update certs generate to client-only output

### DIFF
--- a/crates/imago-cli/src/cli.rs
+++ b/crates/imago-cli/src/cli.rs
@@ -265,28 +265,16 @@ pub struct CertsSubcommandArgs {
 
 #[derive(Debug, Subcommand, Clone, PartialEq, Eq)]
 pub enum CertsCommands {
-    /// Generate local development certificates.
+    /// Generate a local client key for imago-cli authentication.
     Generate(CertsGenerateArgs),
 }
 
-/// Generate local certificates for imagod and client auth.
+/// Generate a local client key for imago-cli authentication.
 #[derive(Debug, Args, Clone, PartialEq, Eq)]
 pub struct CertsGenerateArgs {
-    /// Output directory for generated certificate and key files.
+    /// Output directory for generated key files.
     #[arg(long, value_name = "PATH", default_value = "certs")]
     pub out_dir: PathBuf,
-
-    /// DNS subject name for the server certificate.
-    #[arg(long, value_name = "DNS_NAME", default_value = "localhost")]
-    pub server_name: String,
-
-    /// IP subject alternative name for the server certificate.
-    #[arg(long, value_name = "IP_ADDR", default_value = "127.0.0.1")]
-    pub server_ip: String,
-
-    /// Certificate validity period in days.
-    #[arg(long, value_name = "DAYS", default_value_t = 3650)]
-    pub days: u32,
 
     /// Overwrite existing files in the output directory.
     #[arg(long)]
@@ -789,9 +777,6 @@ mod tests {
                 command: Commands::Certs(CertsSubcommandArgs {
                     command: CertsCommands::Generate(CertsGenerateArgs {
                         out_dir: PathBuf::from("certs"),
-                        server_name: "localhost".to_string(),
-                        server_ip: "127.0.0.1".to_string(),
-                        days: 3650,
                         force: false,
                     }),
                 }),
@@ -807,12 +792,6 @@ mod tests {
             "generate",
             "--out-dir",
             "tmp-certs",
-            "--server-name",
-            "imagod.local",
-            "--server-ip",
-            "192.168.10.2",
-            "--days",
-            "30",
             "--force",
         ])
         .expect("parse should succeed");
@@ -824,14 +803,39 @@ mod tests {
                 command: Commands::Certs(CertsSubcommandArgs {
                     command: CertsCommands::Generate(CertsGenerateArgs {
                         out_dir: PathBuf::from("tmp-certs"),
-                        server_name: "imagod.local".to_string(),
-                        server_ip: "192.168.10.2".to_string(),
-                        days: 30,
                         force: true,
                     }),
                 }),
             }
         );
+    }
+
+    #[test]
+    fn rejects_certs_generate_server_name_option() {
+        let err = Cli::try_parse_from([
+            "imago",
+            "certs",
+            "generate",
+            "--server-name",
+            "imagod.local",
+        ])
+        .expect_err("parse should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn rejects_certs_generate_server_ip_option() {
+        let err =
+            Cli::try_parse_from(["imago", "certs", "generate", "--server-ip", "192.168.10.2"])
+                .expect_err("parse should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn rejects_certs_generate_days_option() {
+        let err = Cli::try_parse_from(["imago", "certs", "generate", "--days", "30"])
+            .expect_err("parse should fail");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]

--- a/crates/imago-cli/src/commands/certs.rs
+++ b/crates/imago-cli/src/commands/certs.rs
@@ -36,11 +36,14 @@ const KNOWN_HOSTS_FILE_NAME: &str = "known_hosts";
 
 #[derive(Debug)]
 struct OutputPaths {
-    server_key: PathBuf,
     client_key: PathBuf,
-    server_pub_hex: PathBuf,
-    client_pub_hex: PathBuf,
     gitignore: PathBuf,
+}
+
+#[derive(Debug)]
+struct GenerateOutput {
+    paths: OutputPaths,
+    client_public_key_hex: String,
 }
 
 pub fn run_generate(args: CertsGenerateArgs) -> CommandResult {
@@ -48,19 +51,20 @@ pub fn run_generate(args: CertsGenerateArgs) -> CommandResult {
     ui::command_start("certs.generate", "starting");
     ui::command_stage("certs.generate", "generate", "creating key material");
     match run_generate_inner(args) {
-        Ok(paths) => {
+        Ok(output) => {
             if ui::current_mode() != ui::UiMode::Json {
                 println!("generated key material:");
-                println!("  {}", paths.server_key.display());
-                println!("  {}", paths.client_key.display());
-                println!("  {}", paths.server_pub_hex.display());
-                println!("  {}", paths.client_pub_hex.display());
-                println!("  {}", paths.gitignore.display());
+                println!("  {}", output.paths.client_key.display());
+                println!("  {}", output.paths.gitignore.display());
+                println!(
+                    "  client_public_key_hex={}",
+                    output.client_public_key_hex.as_str()
+                );
                 println!("private keys are sensitive. do not commit or share them.");
             }
 
             ui::command_finish("certs.generate", true, "completed");
-            CommandResult::success("certs.generate", started_at)
+            success_generate_result(started_at, output.client_public_key_hex)
         }
         Err(err) => {
             let summary_message = err.to_string();
@@ -69,6 +73,14 @@ pub fn run_generate(args: CertsGenerateArgs) -> CommandResult {
             CommandResult::failure("certs.generate", started_at, diagnostic_message)
         }
     }
+}
+
+fn success_generate_result(started_at: Instant, client_public_key_hex: String) -> CommandResult {
+    let mut result = CommandResult::success("certs.generate", started_at);
+    result
+        .meta
+        .insert("client_public_key_hex".to_string(), client_public_key_hex);
+    result
 }
 
 pub async fn run_bindings_cert_upload(args: BindingsCertUploadArgs) -> CommandResult {
@@ -496,49 +508,32 @@ fn format_bindings_cert_deploy_result(from_error: Option<&str>, to_error: Option
     lines.join("\n")
 }
 
-fn run_generate_inner(args: CertsGenerateArgs) -> anyhow::Result<OutputPaths> {
+fn run_generate_inner(args: CertsGenerateArgs) -> anyhow::Result<GenerateOutput> {
     let out_dir = args.out_dir;
     std::fs::create_dir_all(&out_dir)
         .with_context(|| format!("failed to create out dir: {}", out_dir.display()))?;
 
     let paths = OutputPaths {
-        server_key: out_dir.join("server.key"),
         client_key: out_dir.join("client.key"),
-        server_pub_hex: out_dir.join("server.pub.hex"),
-        client_pub_hex: out_dir.join("client.pub.hex"),
         gitignore: out_dir.join(".gitignore"),
     };
 
     ensure_writable_targets(&paths, args.force)?;
 
-    let server_key =
-        KeyPair::generate_for(&PKCS_ED25519).context("failed to generate server keypair")?;
     let client_key =
         KeyPair::generate_for(&PKCS_ED25519).context("failed to generate client keypair")?;
 
-    write_private_key(&paths.server_key, &server_key.serialize_pem())?;
     write_private_key(&paths.client_key, &client_key.serialize_pem())?;
-    write_text(
-        &paths.server_pub_hex,
-        &format!("{}\n", hex::encode(server_key.public_key_raw())),
-    )?;
-    write_text(
-        &paths.client_pub_hex,
-        &format!("{}\n", hex::encode(client_key.public_key_raw())),
-    )?;
     write_text(&paths.gitignore, GITIGNORE_CONTENT)?;
 
-    Ok(paths)
+    Ok(GenerateOutput {
+        paths,
+        client_public_key_hex: hex::encode(client_key.public_key_raw()),
+    })
 }
 
 fn ensure_writable_targets(paths: &OutputPaths, force: bool) -> anyhow::Result<()> {
-    let all_paths = [
-        &paths.server_key,
-        &paths.client_key,
-        &paths.server_pub_hex,
-        &paths.client_pub_hex,
-        &paths.gitignore,
-    ];
+    let all_paths = [&paths.client_key, &paths.gitignore];
 
     if force {
         return Ok(());
@@ -591,37 +586,32 @@ mod tests {
     use crate::cli::BindingsCertUploadArgs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn generates_all_files_and_valid_payloads() {
-        let dir = temp_dir("generates_all_files_and_valid_payloads");
+    fn generates_client_key_and_public_key_hex() {
+        let dir = temp_dir("generates_client_key_and_public_key_hex");
         let args = CertsGenerateArgs {
             out_dir: dir.clone(),
-            server_name: "localhost".to_string(),
-            server_ip: "127.0.0.1".to_string(),
-            days: 3650,
             force: false,
         };
 
-        let paths = run_generate_inner(args).expect("key generation should succeed");
+        let output = run_generate_inner(args).expect("key generation should succeed");
 
-        assert!(paths.server_key.exists());
-        assert!(paths.client_key.exists());
-        assert!(paths.server_pub_hex.exists());
-        assert!(paths.client_pub_hex.exists());
-        assert!(paths.gitignore.exists());
+        assert!(output.paths.client_key.exists());
+        assert!(output.paths.gitignore.exists());
+        assert!(!dir.join("server.key").exists());
+        assert!(!dir.join("server.pub.hex").exists());
+        assert!(!dir.join("client.pub.hex").exists());
 
-        let gitignore = std::fs::read_to_string(&paths.gitignore).expect("read .gitignore");
+        let gitignore = std::fs::read_to_string(&output.paths.gitignore).expect("read .gitignore");
         assert_eq!(gitignore, GITIGNORE_CONTENT);
 
-        assert_has_private_key(&paths.server_key);
-        assert_has_private_key(&paths.client_key);
-        assert_public_key_hex(&paths.server_pub_hex);
-        assert_public_key_hex(&paths.client_pub_hex);
-
-        assert_public_key_matches_private(&paths.server_key, &paths.server_pub_hex);
-        assert_public_key_matches_private(&paths.client_key, &paths.client_pub_hex);
+        assert_has_private_key(&output.paths.client_key);
+        assert_public_key_matches_private(
+            &output.paths.client_key,
+            output.client_public_key_hex.as_str(),
+        );
 
         cleanup(&dir);
     }
@@ -629,21 +619,18 @@ mod tests {
     #[test]
     fn fails_without_force_when_file_exists() {
         let dir = temp_dir("fails_without_force_when_file_exists");
-        let existing = dir.join("server.key");
+        let existing = dir.join("client.key");
         std::fs::write(&existing, "dummy").expect("create existing file");
 
         let args = CertsGenerateArgs {
             out_dir: dir.clone(),
-            server_name: "localhost".to_string(),
-            server_ip: "127.0.0.1".to_string(),
-            days: 3650,
             force: false,
         };
 
         let err = run_generate_inner(args).expect_err("generation should fail");
         let message = err.to_string();
         assert!(message.contains("--force"));
-        assert!(message.contains("server.key"));
+        assert!(message.contains("client.key"));
 
         cleanup(&dir);
     }
@@ -651,22 +638,32 @@ mod tests {
     #[test]
     fn force_overwrites_existing_outputs() {
         let dir = temp_dir("force_overwrites_existing_outputs");
-        let existing = dir.join("server.key");
+        let existing = dir.join("client.key");
         std::fs::write(&existing, "old").expect("create existing file");
 
         let args = CertsGenerateArgs {
             out_dir: dir.clone(),
-            server_name: "localhost".to_string(),
-            server_ip: "127.0.0.1".to_string(),
-            days: 3650,
             force: true,
         };
 
-        let paths = run_generate_inner(args).expect("generation with --force should succeed");
-        let server_key = std::fs::read_to_string(paths.server_key).expect("read server key");
-        assert!(server_key.contains("BEGIN PRIVATE KEY"));
+        let output = run_generate_inner(args).expect("generation with --force should succeed");
+        let client_key = std::fs::read_to_string(output.paths.client_key).expect("read client key");
+        assert!(client_key.contains("BEGIN PRIVATE KEY"));
 
         cleanup(&dir);
+    }
+
+    #[test]
+    fn success_generate_result_sets_client_public_key_hex_meta() {
+        let started_at = Instant::now();
+        let public_key_hex =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string();
+
+        let result = success_generate_result(started_at, public_key_hex.clone());
+        assert_eq!(
+            result.meta.get("client_public_key_hex"),
+            Some(&public_key_hex)
+        );
     }
 
     #[tokio::test]
@@ -766,41 +763,27 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_keys_are_written_with_strict_permissions() {
+    fn private_key_is_written_with_strict_permissions() {
         let dir = temp_dir("private_keys_are_written_with_strict_permissions");
         let args = CertsGenerateArgs {
             out_dir: dir.clone(),
-            server_name: "localhost".to_string(),
-            server_ip: "127.0.0.1".to_string(),
-            days: 3650,
             force: false,
         };
 
-        let paths = run_generate_inner(args).expect("key generation should succeed");
-        assert_mode_0600(&paths.server_key);
-        assert_mode_0600(&paths.client_key);
+        let output = run_generate_inner(args).expect("key generation should succeed");
+        assert_mode_0600(&output.paths.client_key);
 
         cleanup(&dir);
     }
 
-    fn assert_public_key_hex(path: &Path) {
-        let value = std::fs::read_to_string(path).expect("public key file should be readable");
-        let trimmed = value.trim();
-        let decoded = hex::decode(trimmed).expect("public key must be hex");
+    fn assert_public_key_matches_private(private_key_path: &Path, public_key_hex: &str) {
+        let decoded = hex::decode(public_key_hex).expect("public key must be hex");
         assert_eq!(decoded.len(), 32, "ed25519 public key must be 32 bytes");
-    }
-
-    fn assert_public_key_matches_private(private_key_path: &Path, public_key_hex_path: &Path) {
         let private_key_pem =
             std::fs::read_to_string(private_key_path).expect("private key should be readable");
         let key_pair = KeyPair::from_pem(&private_key_pem).expect("private key should parse");
         let expected = hex::encode(key_pair.public_key_raw());
-
-        let actual = std::fs::read_to_string(public_key_hex_path)
-            .expect("public key should be readable")
-            .trim()
-            .to_string();
-        assert_eq!(actual, expected);
+        assert_eq!(public_key_hex, expected);
     }
 
     fn assert_has_private_key(path: &Path) {

--- a/crates/imago-cli/src/main.rs
+++ b/crates/imago-cli/src/main.rs
@@ -346,9 +346,6 @@ mod tests {
             command: Commands::Certs(CertsSubcommandArgs {
                 command: CertsCommands::Generate(crate::cli::CertsGenerateArgs {
                     out_dir: temp.clone(),
-                    server_name: "localhost".to_string(),
-                    server_ip: "127.0.0.1".to_string(),
-                    days: 1,
                     force: true,
                 }),
             }),


### PR DESCRIPTION
## Motivation
- `imago certs generate` が server/client 両方の鍵素材を生成しており、imago-cli の接続用途（`target.<name>.client_key`）に対して過剰でした。
- 不要ファイル（`server.key`, `server.pub.hex`, `client.pub.hex`）の生成をやめ、コマンドの責務を client 側準備に限定して運用を明確化するためです。

## Summary
- `imago certs generate` を client-only に再定義し、生成物を `client.key` と `.gitignore` のみに変更。
- `client_public_key_hex` はファイル保存せず、Rich/Plain では表示、JSON では `command.summary.meta.client_public_key_hex` に格納。
- `CertsGenerateArgs` から未使用オプション `--server-name` / `--server-ip` / `--days` を削除。
- CLI テストと certs コマンドテスト、dispatch テストを新仕様に合わせて更新。
- design/spec の更新は不要（`certs generate` の該当記述なし）。

## Validation
- `cargo fmt --all`
- `cargo test -p imago-cli`
  - Result: 317 passed, 0 failed
