### PR TITLE
Fix runtime native-plugin linker duplication and add NanoKVM e2e

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,8 @@ required-features = ["e2e"]
 name = "e2e_rpc_single"
 path = "tests/e2e_rpc_single.rs"
 required-features = ["e2e"]
+
+[[test]]
+name = "e2e_nanokvm_native_plugin"
+path = "tests/e2e_nanokvm_native_plugin.rs"
+required-features = ["e2e"]

--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,10 @@ fn main() {
         "IMAGO_E2E_WASM_RPC_CALLEE",
         &wasm_dir.join("e2e_rpc_callee.wasm"),
     );
+    export_artifact(
+        "IMAGO_E2E_WASM_NANOKVM_PROBE",
+        &wasm_dir.join("e2e_nanokvm_probe.wasm"),
+    );
 }
 
 fn export_artifact(key: &str, path: &Path) {

--- a/crates/imagod-runtime-wasmtime/src/plugin_resolver.rs
+++ b/crates/imagod-runtime-wasmtime/src/plugin_resolver.rs
@@ -222,7 +222,6 @@ where
                         dep.name
                     ))
                 })?;
-
                 let self_instance = Arc::new(tokio::sync::Mutex::new(None));
                 register_plugin_import_shims(
                     resolver,
@@ -286,7 +285,7 @@ pub(crate) fn register_plugin_import_shims(
     let component_ty = component.component_type();
     let self_export_interfaces = collect_component_instance_export_names(component, engine);
     let allow_self_provider = self_instance.is_some();
-    let mut linked_native_imports = BTreeSet::<String>::new();
+    let mut linked_native_plugin_packages = BTreeSet::<String>::new();
     let available_dependency_names = available_plugins.keys().cloned().collect::<BTreeSet<_>>();
     let binding_targets = build_binding_target_map(bindings)?;
 
@@ -370,8 +369,23 @@ pub(crate) fn register_plugin_import_shims(
                     )));
                 }
             }
-            if linked_native_imports.insert(import_name.to_string()) {
-                native_plugin.add_to_linker(linker)?;
+            if mark_native_plugin_linked(
+                &mut linked_native_plugin_packages,
+                native_plugin.package_name(),
+            ) {
+                linker.allow_shadowing(true);
+                let link_result = (|| -> Result<(), ImagodError> {
+                    native_plugin.add_to_linker(linker)?;
+                    add_to_linker_async(linker).map_err(|e| {
+                        map_runtime_error(format!(
+                            "failed to refresh WASI linker after native plugin '{}' link: {e}",
+                            native_plugin.package_name()
+                        ))
+                    })?;
+                    Ok(())
+                })();
+                linker.allow_shadowing(false);
+                link_result?;
             }
             continue;
         }
@@ -788,6 +802,13 @@ fn parse_import_package_name(import_name: &str) -> Option<&str> {
         .map(|(package_name, _)| package_name)
 }
 
+fn mark_native_plugin_linked(
+    linked_native_plugin_packages: &mut BTreeSet<String>,
+    package_name: &str,
+) -> bool {
+    linked_native_plugin_packages.insert(package_name.to_string())
+}
+
 fn ensure_component_signatures_match(
     import_ty: &types::ComponentFunc,
     callee_ty: &types::ComponentFunc,
@@ -1056,6 +1077,24 @@ mod tests {
             err.message.contains("maps to multiple services"),
             "unexpected message: {}",
             err.message
+        );
+    }
+
+    #[test]
+    fn mark_native_plugin_linked_is_package_scoped() {
+        let mut linked_native_plugin_packages = BTreeSet::new();
+
+        assert!(
+            mark_native_plugin_linked(&mut linked_native_plugin_packages, "imago:nanokvm"),
+            "first import from same package should link once"
+        );
+        assert!(
+            !mark_native_plugin_linked(&mut linked_native_plugin_packages, "imago:nanokvm"),
+            "second import from same package should not relink"
+        );
+        assert!(
+            mark_native_plugin_linked(&mut linked_native_plugin_packages, "imago:node"),
+            "another package should still link"
         );
     }
 }

--- a/crates/imagod-runtime-wasmtime/src/runtime_entry.rs
+++ b/crates/imagod-runtime-wasmtime/src/runtime_entry.rs
@@ -27,8 +27,7 @@ use wasmtime::{
     component::{Component, Func, Linker},
 };
 use wasmtime_wasi::{
-    DirPerms, FilePerms, WasiCtxBuilder,
-    p2::{add_to_linker_async, bindings::Command},
+    DirPerms, FilePerms, WasiCtxBuilder, p2::add_to_linker_async, p2::bindings::Command,
     sockets::SocketAddrUse,
 };
 use wasmtime_wasi_http::{add_only_http_to_linker_async, bindings::Proxy};

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -25,6 +25,10 @@ required-features = ["e2e"]
 name = "e2e_rpc_callee"
 required-features = ["e2e"]
 
+[[bin]]
+name = "e2e_nanokvm_probe"
+required-features = ["e2e"]
+
 [dependencies]
 wit-bindgen = {version = "0.53.1", optional = true}
 wasi = {version = "0.14.7", optional = true}

--- a/e2e/src/bin/e2e_nanokvm_probe.rs
+++ b/e2e/src/bin/e2e_nanokvm_probe.rs
@@ -1,0 +1,28 @@
+use wit_bindgen::generate;
+
+generate!({
+    world: "nanokvm-probe",
+    generate_all
+});
+
+fn main() {
+    println!("nanokvm-probe: start");
+
+    match imago::nanokvm::stream_config::get_server_config_yaml() {
+        Ok(yaml) => println!("nanokvm-probe: stream-config ok bytes={}", yaml.len()),
+        Err(err) => println!("nanokvm-probe: stream-config err={err}"),
+    }
+
+    match imago::nanokvm::device_status::get_usb_mode() {
+        Ok(mode) => {
+            let mode_text = match mode {
+                imago::nanokvm::device_status::UsbMode::Normal => "normal",
+                imago::nanokvm::device_status::UsbMode::HidOnly => "hid-only",
+            };
+            println!("nanokvm-probe: device-status ok usb-mode={mode_text}");
+        }
+        Err(err) => println!("nanokvm-probe: device-status err={err}"),
+    }
+
+    println!("nanokvm-probe: completed");
+}

--- a/e2e/wit/deps/imago-nanokvm/package.wit
+++ b/e2e/wit/deps/imago-nanokvm/package.wit
@@ -1,0 +1,19 @@
+package imago:nanokvm@0.1.0;
+
+interface stream-config {
+    get-server-config-yaml: func() -> result<string, string>;
+}
+
+interface device-status {
+    enum usb-mode {
+        normal,
+        hid-only,
+    }
+
+    get-usb-mode: func() -> result<usb-mode, string>;
+}
+
+world host {
+    import stream-config;
+    import device-status;
+}

--- a/e2e/wit/world.wit
+++ b/e2e/wit/world.wit
@@ -3,3 +3,8 @@ package e2e:components;
 world rpc-caller {
   import acme:clock/api;
 }
+
+world nanokvm-probe {
+  import imago:nanokvm/stream-config@0.1.0;
+  import imago:nanokvm/device-status@0.1.0;
+}

--- a/tests/e2e_helper/cluster.rs
+++ b/tests/e2e_helper/cluster.rs
@@ -13,6 +13,7 @@ pub struct Cluster {
     workspace_root: PathBuf,
     base_dir: PathBuf,
     control_admin_public_hex: String,
+    daemon_package: String,
     nodes: Vec<Node>,
     running: Vec<NodeProcess>,
 }
@@ -50,12 +51,22 @@ impl Cluster {
         base_dir: PathBuf,
         control_admin_public_hex: String,
     ) -> Result<Self> {
+        Self::new_with_daemon_package(workspace_root, base_dir, control_admin_public_hex, "imagod")
+    }
+
+    pub fn new_with_daemon_package(
+        workspace_root: PathBuf,
+        base_dir: PathBuf,
+        control_admin_public_hex: String,
+        daemon_package: impl Into<String>,
+    ) -> Result<Self> {
         fs::create_dir_all(&base_dir)
             .with_context(|| format!("failed to create {}", base_dir.display()))?;
         Ok(Self {
             workspace_root,
             base_dir,
             control_admin_public_hex,
+            daemon_package: daemon_package.into(),
             nodes: Vec::new(),
             running: Vec::new(),
         })
@@ -127,7 +138,7 @@ impl Cluster {
                 .arg("--manifest-path")
                 .arg(self.workspace_root.join("Cargo.toml"))
                 .arg("-p")
-                .arg("imagod")
+                .arg(&self.daemon_package)
                 .arg("--")
                 .arg("--config")
                 .arg(&node.imagod_config_path)

--- a/tests/e2e_helper/scenario.rs
+++ b/tests/e2e_helper/scenario.rs
@@ -71,6 +71,10 @@ pub struct Scenario {
 
 impl Scenario {
     pub fn new(test_name: &str) -> TestResult<Self> {
+        Self::new_with_daemon_package(test_name, "imagod")
+    }
+
+    pub fn new_with_daemon_package(test_name: &str, daemon_package: &str) -> TestResult<Self> {
         let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let prefix = short_prefix(test_name);
         let temp_dir = TempDirBuilder::new().prefix(&prefix).tempdir()?;
@@ -83,10 +87,11 @@ impl Scenario {
         let control_home = root.join("h");
         fs::create_dir_all(&control_home)?;
 
-        let cluster = Cluster::new(
+        let cluster = Cluster::new_with_daemon_package(
             workspace_root.clone(),
             root.join("n"),
             control_keys.admin_public_hex,
+            daemon_package,
         )?;
         let projects_base_dir = root.join("p");
         fs::create_dir_all(&projects_base_dir)?;

--- a/tests/e2e_helper/wasm_assets.rs
+++ b/tests/e2e_helper/wasm_assets.rs
@@ -7,6 +7,7 @@ pub enum WasmArtifact {
     Http,
     RpcCaller,
     RpcCallee,
+    NanoKvmProbe,
 }
 
 pub fn wasm_path(artifact: WasmArtifact) -> Result<PathBuf> {
@@ -25,6 +26,7 @@ pub fn wasm_file_name(artifact: WasmArtifact) -> &'static str {
         WasmArtifact::Http => "e2e_http.wasm",
         WasmArtifact::RpcCaller => "e2e_rpc_caller.wasm",
         WasmArtifact::RpcCallee => "e2e_rpc_callee.wasm",
+        WasmArtifact::NanoKvmProbe => "e2e_nanokvm_probe.wasm",
     }
 }
 
@@ -34,5 +36,6 @@ fn artifact_env_key(artifact: WasmArtifact) -> &'static str {
         WasmArtifact::Http => "IMAGO_E2E_WASM_HTTP",
         WasmArtifact::RpcCaller => "IMAGO_E2E_WASM_RPC_CALLER",
         WasmArtifact::RpcCallee => "IMAGO_E2E_WASM_RPC_CALLEE",
+        WasmArtifact::NanoKvmProbe => "IMAGO_E2E_WASM_NANOKVM_PROBE",
     }
 }

--- a/tests/e2e_nanokvm_native_plugin.rs
+++ b/tests/e2e_nanokvm_native_plugin.rs
@@ -1,0 +1,128 @@
+#[path = "e2e_helper/mod.rs"]
+mod e2e_helper;
+
+use e2e_helper::{AppKind, CmdOutput, Scenario, ServiceHandle, TestResult, WasmArtifact};
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
+
+const COMPLETED_MARKER: &str = "nanokvm-probe: completed";
+const LINKER_DUPLICATE_MARKER: &str = "map entry `wasi:io/error@0.2.6` defined twice";
+
+#[test]
+#[ignore]
+fn e2e_nanokvm_native_plugin_multi_import_does_not_duplicate_linker_entries() -> TestResult {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut scenario = Scenario::new_with_daemon_package("e2e-nanokvm", "nanokvm-imagod")?;
+    let _default = scenario.cluster().add_node("default")?;
+    scenario.cluster().start_all()?;
+
+    let service = scenario.add_service(
+        "e2e-nanokvm-probe",
+        AppKind::Cli,
+        "default",
+        WasmArtifact::NanoKvmProbe,
+    )?;
+
+    let nanokvm_wit = workspace_root
+        .join("plugins")
+        .join("imago-plugin-nanokvm-plugin")
+        .join("wit");
+
+    service.append_imago_toml(
+        &scenario,
+        &format!(
+            "\n[[dependencies]]\nname = \"imago:nanokvm\"\nversion = \"0.1.0\"\nkind = \"native\"\nwit = \"file://{}\"\n\n[capabilities.deps]\n\"imago:nanokvm\" = [\"*\"]\n",
+            toml_escape(nanokvm_wit.to_string_lossy().as_ref()),
+        ),
+    )?;
+
+    let update = scenario.run_service_cli(service.name(), &["update"])?;
+    ensure_success("nanokvm update", &update)?;
+
+    let deploy = scenario.run_service_cli(service.name(), &["deploy", "--target", "default"])?;
+    assert_not_defined_twice("nanokvm deploy", &deploy)?;
+    ensure_success("nanokvm deploy", &deploy)?;
+    assert_command_completed("nanokvm deploy", &deploy)?;
+
+    let logs = wait_logs_with_marker(&service, &scenario, "default", 200, COMPLETED_MARKER, 40)?;
+    assert!(
+        !logs.contains(LINKER_DUPLICATE_MARKER),
+        "unexpected linker duplicate marker in logs: {logs}"
+    );
+
+    let _ = service.stop(&scenario, "default");
+    Ok(())
+}
+
+fn wait_logs_with_marker(
+    service: &ServiceHandle,
+    scenario: &Scenario,
+    _target: &str,
+    tail: u32,
+    marker: &str,
+    retries: usize,
+) -> TestResult<String> {
+    let tail_text = tail.to_string();
+    let args = ["logs", service.name(), "--tail", tail_text.as_str()];
+    let mut last_combined = String::new();
+
+    for _ in 0..retries {
+        let output = scenario.run_service_cli(service.name(), &args)?;
+        if output.success {
+            let logs = output.log_messages().join("\n");
+            if logs.contains(marker) {
+                return Ok(logs);
+            }
+        }
+        last_combined = output.combined;
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    Err(anyhow::anyhow!(
+        "timed out waiting for marker '{marker}', last output: {last_combined}"
+    ))
+}
+
+fn ensure_success(label: &str, output: &CmdOutput) -> TestResult {
+    if output.success {
+        return Ok(());
+    }
+    Err(anyhow::anyhow!(
+        "{label} failed: status={}, stdout={}, stderr={}",
+        output.status,
+        output.stdout,
+        output.stderr
+    ))
+}
+
+fn assert_command_completed(label: &str, output: &CmdOutput) -> TestResult {
+    match output.command_summary_status().as_deref() {
+        Some("completed") => Ok(()),
+        Some(status) => Err(anyhow::anyhow!(
+            "{label} summary status was '{status}', expected 'completed': {}",
+            output.combined
+        )),
+        None => Err(anyhow::anyhow!(
+            "{label} command.summary was not found: {}",
+            output.combined
+        )),
+    }
+}
+
+fn assert_not_defined_twice(label: &str, output: &CmdOutput) -> TestResult {
+    if output.combined.contains(LINKER_DUPLICATE_MARKER)
+        || (output.combined.contains("runtime.native_plugin")
+            && output.combined.contains("defined twice"))
+    {
+        return Err(anyhow::anyhow!(
+            "{label} hit linker duplicate regression: {}",
+            output.combined
+        ));
+    }
+    Ok(())
+}
+
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}


### PR DESCRIPTION
## Motivation
- `runtime.native_plugin` で `map entry `wasi:io/error@0.2.6` defined twice` が発生し、`imago:nanokvm` の複数 interface import を含むデプロイが失敗していました。
- root cause は runtime linker 上で native plugin が追加する `wasi:io/*` 登録と runtime 側 WASI 登録の衝突です。runtime 側で再発を防ぐ必要がありました。
- あわせて NanoKVM 実運用経路に近い ignored e2e を追加し、同種回帰を CI/ローカルで検知できるようにします。

## Summary
- `crates/imagod-runtime-wasmtime/src/plugin_resolver.rs` を修正。
- native plugin の重複判定を import 名単位から package 名単位に変更し、同一 package では `add_to_linker` を1回だけ実行するようにしました。
- `supports_import` / symbol 検証 / capability 検証 / 型整合の既存ロジックは維持しています。
- native plugin linker 登録時に `linker.allow_shadowing(true)` で登録し、その直後に async WASI linker を再適用して `wasi:io/*` の衝突と runtime nested-panic を回避しました（plugin 実装側は未変更）。
- `plugin_resolver` の unit test に package 単位重複抑止の回帰テストを追加しました。
- e2e helper を拡張し、既存 `Cluster::new` / `Scenario::new` の互換を保ったまま daemon package 指定版 constructor を追加しました。
- NanoKVM 再現 e2e を追加。
  - `e2e_nanokvm_probe` wasm を追加（`imago:nanokvm/stream-config` と `imago:nanokvm/device-status` を import）
  - `build.rs` / `tests/e2e_helper/wasm_assets.rs` / `e2e/Cargo.toml` を更新
  - `tests/e2e_nanokvm_native_plugin.rs` を追加し、`Scenario::new_with_daemon_package(..., "nanokvm-imagod")` + native dependency (`imago:nanokvm`) + `imago update` + `deploy` + marker 検証 + `defined twice` 非再発を確認

## Validation
- `cargo test -p imagod-runtime-wasmtime`
- `cargo test -p imago --features e2e --test e2e_nanokvm_native_plugin -- --ignored --test-threads=1`
- `cargo test -p imago --features e2e -- --ignored --test-threads=1`
