### PR TITLE
Split PR body checks workflow and allow Dependabot

### DIFF
--- a/.github/workflows/ci-pr-body-checks.yml
+++ b/.github/workflows/ci-pr-body-checks.yml
@@ -1,0 +1,83 @@
+name: ci-pr-body-checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-pr-body-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr_body_lint:
+    name: pr body lint
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: imago-default-runner-set
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate pull request body sections
+        run: python3 .github/scripts/lint_pr_body.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+
+  allow_dependabot:
+    name: allow dependabot
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: imago-default-runner-set
+    steps:
+      - name: Allow dependabot pull request
+        run: echo "Dependabot pull request is exempt from PR body lint."
+
+  checks:
+    name: checks
+    needs:
+      - pr_body_lint
+      - allow_dependabot
+    if: always()
+    runs-on: imago-default-runner-set
+    steps:
+      - name: Evaluate required checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          is_dependabot="${{ github.event.pull_request.user.login == 'dependabot[bot]' }}"
+          lint_result='${{ needs.pr_body_lint.result }}'
+          allow_result='${{ needs.allow_dependabot.result }}'
+
+          echo "is_dependabot: $is_dependabot"
+          echo "pr_body_lint: $lint_result"
+          echo "allow_dependabot: $allow_result"
+
+          if [[ "$is_dependabot" == "true" ]]; then
+            [[ "$allow_result" == "success" ]] || {
+              echo "::error::allow_dependabot must succeed for Dependabot pull requests."
+              exit 1
+            }
+
+            [[ "$lint_result" == "skipped" || "$lint_result" == "success" ]] || {
+              echo "::error::pr_body_lint must be skipped or succeed for Dependabot pull requests."
+              exit 1
+            }
+          else
+            [[ "$lint_result" == "success" ]] || {
+              echo "::error::pr_body_lint must succeed for non-Dependabot pull requests."
+              exit 1
+            }
+
+            [[ "$allow_result" == "skipped" || "$allow_result" == "success" ]] || {
+              echo "::error::allow_dependabot must be skipped or succeed for non-Dependabot pull requests."
+              exit 1
+            }
+          fi

--- a/.github/workflows/ci-rust-checks.yml
+++ b/.github/workflows/ci-rust-checks.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: ci-rust-checks-${{ github.ref }}
@@ -122,26 +121,11 @@ jobs:
       - name: cargo check
         run: cargo check --workspace
 
-  pr_body_lint:
-    name: pr body lint
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: imago-default-runner-set
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Validate pull request body sections
-        run: python3 .github/scripts/lint_pr_body.py
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-
   checks:
     name: checks
     needs:
       - changed
       - rust_checks
-      - pr_body_lint
     if: always()
     runs-on: imago-default-runner-set
     steps:
@@ -156,7 +140,6 @@ jobs:
           workflow_related='${{ needs.changed.outputs.workflow_related }}'
           plugin_wit_related='${{ needs.changed.outputs.plugin_wit_related }}'
           rust_result='${{ needs.rust_checks.result }}'
-          pr_body_lint_result='${{ needs.pr_body_lint.result }}'
 
           echo "event_name: $event_name"
           echo "changed: $changed_result"
@@ -164,7 +147,6 @@ jobs:
           echo "workflow_related: $workflow_related"
           echo "plugin_wit_related: $plugin_wit_related"
           echo "rust_checks: $rust_result"
-          echo "pr_body_lint: $pr_body_lint_result"
 
           [[ "$changed_result" == "success" ]] || {
             echo "::error::changed job failed ($changed_result)"
@@ -172,11 +154,6 @@ jobs:
           }
 
           if [[ "$event_name" == "pull_request" ]]; then
-            [[ "$pr_body_lint_result" == "success" ]] || {
-              echo "::error::pr_body_lint must succeed for pull requests."
-              exit 1
-            }
-
             if [[ "$rust_related" == "true" || "$workflow_related" == "true" || "$plugin_wit_related" == "true" ]]; then
               [[ "$rust_result" == "success" ]] || {
                 echo "::error::rust_checks must succeed when Rust/workflow/plugin WIT files are changed."
@@ -191,11 +168,6 @@ jobs:
           else
             [[ "$rust_result" == "success" ]] || {
               echo "::error::rust_checks must succeed on push and workflow_dispatch events."
-              exit 1
-            }
-
-            [[ "$pr_body_lint_result" == "skipped" || "$pr_body_lint_result" == "success" ]] || {
-              echo "::error::pr_body_lint must be skipped or succeed outside pull requests."
               exit 1
             }
           fi


### PR DESCRIPTION
## Motivation
`ci-rust-checks` に PR 本文 lint が同居しており、Dependabot PR でも本文必須チェックが走って失敗する。
本文チェックの責務を分離し、Dependabot PR は明示的に許可できる構成にするため。

## Summary
- 新規 workflow `.github/workflows/ci-pr-body-checks.yml` を追加。
- `pr_body_lint` を通常 PR のみ実行し、`pull_request.user.login == 'dependabot[bot]'` の場合は `allow_dependabot` を成功させて本文チェックを免除。
- `checks` ジョブを新workflow内に作り、Dependabot/通常PRそれぞれの期待結果を評価。
- `.github/workflows/ci-rust-checks.yml` から `pr_body_lint` ジョブと関連依存を削除し、Rust/Workflow/WIT 判定の責務に限定。

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-rust-checks.yml'); YAML.load_file('.github/workflows/ci-pr-body-checks.yml'); puts 'yaml-ok'"`
  - 結果: `yaml-ok`
- `actionlint` はローカル環境に未インストールのため未実行。
