### PR TITLE
Split WKG checks into dedicated CI workflow

### DIFF
--- a/.github/workflows/ci-rust-checks.yml
+++ b/.github/workflows/ci-rust-checks.yml
@@ -26,7 +26,6 @@ jobs:
     outputs:
       rust_related: ${{ steps.detect.outputs.rust_related }}
       workflow_related: ${{ steps.detect.outputs.workflow_related }}
-      plugin_wit_related: ${{ steps.detect.outputs.plugin_wit_related }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -41,7 +40,6 @@ jobs:
 
           rust_related=false
           workflow_related=false
-          plugin_wit_related=false
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             base_sha='${{ github.event.pull_request.base.sha }}'
@@ -52,41 +50,35 @@ jobs:
               [[ -n "$file" ]] || continue
 
               case "$file" in
+                plugins/*/wkg.lock)
+                  ;;
                 Cargo.toml|Cargo.lock|build.rs|crates/*|src/*|tests/*|e2e/*|examples/*|plugins/*)
                   rust_related=true
                   ;;
               esac
+
+              if [[ "$file" =~ ^plugins/[^/]+/wit/ ]]; then
+                rust_related=true
+              fi
 
               case "$file" in
                 .github/workflows/*|.github/codex/*)
                   workflow_related=true
                   ;;
               esac
-
-              if [[ "$file" =~ ^plugins/[^/]+/wit/ ]]; then
-                plugin_wit_related=true
-              fi
-
-              case "$file" in
-                plugins/*/wkg.lock|.github/scripts/verify_plugin_wkg_locks.sh)
-                  plugin_wit_related=true
-                  ;;
-              esac
             done <<< "$diff_output"
           else
             rust_related=true
             workflow_related=true
-            plugin_wit_related=true
           fi
 
           echo "rust_related=$rust_related" >> "$GITHUB_OUTPUT"
           echo "workflow_related=$workflow_related" >> "$GITHUB_OUTPUT"
-          echo "plugin_wit_related=$plugin_wit_related" >> "$GITHUB_OUTPUT"
 
   rust_checks:
     name: rust checks
     needs: changed
-    if: ${{ needs.changed.outputs.rust_related == 'true' || needs.changed.outputs.workflow_related == 'true' || needs.changed.outputs.plugin_wit_related == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.changed.outputs.rust_related == 'true' || needs.changed.outputs.workflow_related == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: imago-default-runner-set
     steps:
       - name: Checkout
@@ -99,15 +91,6 @@ jobs:
 
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
-
-      - name: Install wkg
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wkg
-
-      - name: Verify plugin wkg locks
-        if: ${{ needs.changed.outputs.plugin_wit_related == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        run: ./.github/scripts/verify_plugin_wkg_locks.sh
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -138,14 +121,12 @@ jobs:
           changed_result='${{ needs.changed.result }}'
           rust_related='${{ needs.changed.outputs.rust_related }}'
           workflow_related='${{ needs.changed.outputs.workflow_related }}'
-          plugin_wit_related='${{ needs.changed.outputs.plugin_wit_related }}'
           rust_result='${{ needs.rust_checks.result }}'
 
           echo "event_name: $event_name"
           echo "changed: $changed_result"
           echo "rust_related: $rust_related"
           echo "workflow_related: $workflow_related"
-          echo "plugin_wit_related: $plugin_wit_related"
           echo "rust_checks: $rust_result"
 
           [[ "$changed_result" == "success" ]] || {
@@ -154,9 +135,9 @@ jobs:
           }
 
           if [[ "$event_name" == "pull_request" ]]; then
-            if [[ "$rust_related" == "true" || "$workflow_related" == "true" || "$plugin_wit_related" == "true" ]]; then
+            if [[ "$rust_related" == "true" || "$workflow_related" == "true" ]]; then
               [[ "$rust_result" == "success" ]] || {
-                echo "::error::rust_checks must succeed when Rust/workflow/plugin WIT files are changed."
+                echo "::error::rust_checks must succeed when Rust/workflow files are changed."
                 exit 1
               }
             else

--- a/.github/workflows/ci-wkg-checks.yml
+++ b/.github/workflows/ci-wkg-checks.yml
@@ -1,0 +1,150 @@
+name: ci-wkg-checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-wkg-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changed:
+    name: detect changes
+    runs-on: imago-default-runner-set
+    outputs:
+      wkg_related: ${{ steps.detect.outputs.wkg_related }}
+      workflow_related: ${{ steps.detect.outputs.workflow_related }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          wkg_related=false
+          workflow_related=false
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha='${{ github.event.pull_request.base.sha }}'
+            head_sha='${{ github.event.pull_request.head.sha }}'
+            diff_output="$(git diff --name-only --no-renames "$base_sha...$head_sha")"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            before_sha='${{ github.event.before }}'
+            head_sha='${{ github.sha }}'
+            if [[ "$before_sha" =~ ^0+$ ]]; then
+              diff_output="$(git ls-tree -r --name-only "$head_sha")"
+            else
+              diff_output="$(git diff --name-only --no-renames "$before_sha...$head_sha")"
+            fi
+          else
+            wkg_related=true
+            workflow_related=true
+            diff_output=""
+          fi
+
+          while IFS= read -r file; do
+            [[ -n "$file" ]] || continue
+
+            if [[ "$file" =~ ^plugins/[^/]+/wit/ ]]; then
+              wkg_related=true
+            fi
+
+            case "$file" in
+              plugins/*/wkg.lock|.github/scripts/verify_plugin_wkg_locks.sh)
+                wkg_related=true
+                ;;
+            esac
+
+            case "$file" in
+              .github/workflows/ci-wkg-checks.yml)
+                workflow_related=true
+                ;;
+            esac
+          done <<< "$diff_output"
+
+          echo "wkg_related=$wkg_related" >> "$GITHUB_OUTPUT"
+          echo "workflow_related=$workflow_related" >> "$GITHUB_OUTPUT"
+
+  wkg_checks:
+    name: wkg checks
+    needs: changed
+    if: ${{ needs.changed.outputs.wkg_related == 'true' || needs.changed.outputs.workflow_related == 'true' || github.event_name == 'workflow_dispatch' }}
+    runs-on: imago-default-runner-set
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install wkg
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wkg
+
+      - name: Verify plugin wkg locks
+        run: ./.github/scripts/verify_plugin_wkg_locks.sh
+
+  checks:
+    name: checks
+    needs:
+      - changed
+      - wkg_checks
+    if: always()
+    runs-on: imago-default-runner-set
+    steps:
+      - name: Evaluate required checks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          event_name='${{ github.event_name }}'
+          changed_result='${{ needs.changed.result }}'
+          wkg_related='${{ needs.changed.outputs.wkg_related }}'
+          workflow_related='${{ needs.changed.outputs.workflow_related }}'
+          wkg_result='${{ needs.wkg_checks.result }}'
+
+          echo "event_name: $event_name"
+          echo "changed: $changed_result"
+          echo "wkg_related: $wkg_related"
+          echo "workflow_related: $workflow_related"
+          echo "wkg_checks: $wkg_result"
+
+          [[ "$changed_result" == "success" ]] || {
+            echo "::error::changed job failed ($changed_result)"
+            exit 1
+          }
+
+          if [[ "$event_name" == "workflow_dispatch" ]]; then
+            [[ "$wkg_result" == "success" ]] || {
+              echo "::error::wkg_checks must succeed on workflow_dispatch events."
+              exit 1
+            }
+            exit 0
+          fi
+
+          if [[ "$wkg_related" == "true" || "$workflow_related" == "true" ]]; then
+            [[ "$wkg_result" == "success" ]] || {
+              echo "::error::wkg_checks must succeed when WKG/workflow files are changed."
+              exit 1
+            }
+          else
+            [[ "$wkg_result" == "skipped" || "$wkg_result" == "success" ]] || {
+              echo "::error::wkg_checks must be skipped or succeed when no WKG-related files are changed."
+              exit 1
+            }
+          fi

--- a/docs/ABOUT_WIT.md
+++ b/docs/ABOUT_WIT.md
@@ -57,7 +57,7 @@ privileged = false
 - `plugins/*` 配下で `wit/package.wit` を持つ native plugin は、同じディレクトリに `wkg.lock` を必ずコミットします。
 - WIT を変更したら plugin ディレクトリで `wkg wit build` を実行し、`wkg.lock` を更新します。
   - 例: `(cd plugins/imago-admin && wkg wit build)`
-- CI (`ci-rust-checks`) は `./.github/scripts/verify_plugin_wkg_locks.sh` で `wkg.lock` の整合性を検証し、不整合を失敗として扱います。
+- CI (`ci-wkg-checks`) は `./.github/scripts/verify_plugin_wkg_locks.sh` で `wkg.lock` の整合性を検証し、不整合を失敗として扱います。
 - native plugin WIT の publish は Git tag を `<plugin-dir>@<version>` 形式で push して行います。
   - 例: `imago-admin@0.1.0`
   - `<version>` は必ず `plugins/<plugin-dir>/wit/package.wit` の `package ...@<version>;` と一致している必要があります。


### PR DESCRIPTION
## Motivation
- `ci-rust-checks` で `wkg` をインストールして lock 検証まで行っており、`wkg` 非関連の変更でも余分な処理が走っていました。
- `wkg` 検証を独立し、関連差分がない場合に `install wkg` をスキップして CI コストを下げつつ、必要な検証は維持するためです。

## Summary
- 新規 workflow `.github/workflows/ci-wkg-checks.yml` を追加。
- `plugins/*/wit/**` / `plugins/*/wkg.lock` / `.github/scripts/verify_plugin_wkg_locks.sh` / `.github/workflows/ci-wkg-checks.yml` の差分を検出し、該当時のみ `Install wkg` と `Verify plugin wkg locks` を実行。
- `workflow_dispatch` では `ci-wkg-checks` を常時実行。
- `.github/workflows/ci-rust-checks.yml` から `Install wkg` / `Verify plugin wkg locks` を削除し、`plugin_wit_related` 判定も削除。
- `plugins/*/wit/**` は引き続き Rust 変更として `rust_related=true`。
- `plugins/*/wkg.lock` は Rust 判定から除外（WKG チェック側に責務を集約）。
- `docs/ABOUT_WIT.md` の CI 記述を `ci-wkg-checks` に更新。

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-rust-checks.yml"); YAML.load_file(".github/workflows/ci-wkg-checks.yml"); puts "yaml-ok"'`
  - 結果: `yaml-ok`
- `git diff --check`
  - 結果: 出力なし（問題なし）
