### PR TITLE
Stop mirroring WASM stdout/stderr to imagod console

### DIFF
--- a/crates/imagod-control/src/service_supervisor/log_buffer.rs
+++ b/crates/imagod-control/src/service_supervisor/log_buffer.rs
@@ -86,17 +86,6 @@ pub(super) fn spawn_log_drain<R>(
                 stream,
                 bytes: chunk[..read].to_vec(),
             });
-
-            let text = String::from_utf8_lossy(&chunk[..read]);
-            for line in text.lines() {
-                if line.is_empty() {
-                    continue;
-                }
-                eprintln!(
-                    "service log name={} stream={} msg={}",
-                    service_name, stream_name, line
-                );
-            }
         }
     });
 }
@@ -118,4 +107,71 @@ pub(super) fn tail_lines_from_bytes(bytes: &[u8], tail_lines: u32) -> Vec<u8> {
     }
     let start = line_starts[line_starts.len() - tail_lines as usize];
     bytes[start..].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::{AsyncWriteExt, duplex};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn spawn_log_drain_updates_buffers_and_broadcast_stream() {
+        let stream_bytes = b"hello-from-wasm\nline-2\n";
+        let expected = stream_bytes.to_vec();
+        let per_stream = Arc::new(Mutex::new(BoundedLogBuffer::new(256)));
+        let composite = Arc::new(Mutex::new(BoundedLogBuffer::new(256)));
+        let (sender, _) = broadcast::channel(16);
+        let mut receiver = sender.subscribe();
+        let (mut writer, reader) = duplex(256);
+
+        spawn_log_drain(
+            reader,
+            per_stream.clone(),
+            composite.clone(),
+            sender,
+            "svc-test".to_string(),
+            "stdout",
+            ServiceLogStream::Stdout,
+        );
+
+        writer
+            .write_all(stream_bytes)
+            .await
+            .expect("write to in-memory stream should succeed");
+        writer
+            .shutdown()
+            .await
+            .expect("shutdown on in-memory stream should succeed");
+        drop(writer);
+
+        let mut received_bytes = Vec::new();
+        loop {
+            match tokio::time::timeout(Duration::from_millis(100), receiver.recv()).await {
+                Ok(Ok(event)) => {
+                    assert_eq!(event.stream, ServiceLogStream::Stdout);
+                    received_bytes.extend_from_slice(&event.bytes);
+                }
+                Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(broadcast::error::RecvError::Closed)) => break,
+                Err(_) => break,
+            }
+        }
+        assert_eq!(received_bytes, expected);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let per_stream_snapshot = { per_stream.lock().await.snapshot() };
+                let composite_snapshot = { composite.lock().await.snapshot() };
+                if per_stream_snapshot == expected && composite_snapshot == expected {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("log drain should publish snapshots");
+    }
 }


### PR DESCRIPTION
## Motivation
- imagod のコンソール（stderr）に WASM サービスの stdout/stderr が行単位で重複表示され、daemon の運用ログがノイズ化していた。
- 既存の `imago logs` と起動失敗時 structured error (`wasm.stdout` / `wasm.stderr`) で必要なログは取得できるため、console への転送のみ停止したい。

## Summary
- `crates/imagod-control/src/service_supervisor/log_buffer.rs` の `spawn_log_drain` から、WASM ログ行を `eprintln!` する処理を削除。
- 以下の既存挙動は維持:
  - per-stream/composite の `BoundedLogBuffer` への保存
  - `broadcast::Sender<ServiceLogEvent>` での配信
  - 読み取り失敗時の `service log read error ...` エラー出力
- `spawn_log_drain` がバッファ更新と broadcast 配信を維持することを確認するユニットテストを追加。

## Validation
- `cargo fmt --all`
- `cargo test -p imagod-control spawn_log_drain_updates_buffers_and_broadcast_stream`
- `cargo test -p imagod-control attach_start_failure_wasm_log_details_adds_details_only_when_enabled`
- `cargo test -p imagod-control open_logs_returns_tail_snapshot_and_follow_receiver`
- 結果: すべて成功
