### PR TITLE
Add auto log follow after run/deploy with detach opt-out

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -52,7 +52,7 @@ cargo run -p imagod -- --config imagod.toml
 # ターミナル2
 cd examples/local-imagod
 # ターミナル1 で imagod が起動したことを確認してから実行
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-app --tail 200
 ```
 
@@ -61,7 +61,7 @@ cargo run -p imago-cli -- logs local-imagod-app --tail 200
 既定（Rich）または `CI=true`（Plain）では、`imago-cli logs` の出力に次の形式で `local-imagod-app started` が含まれていれば成功です。
 
 ```text
-1739982001 local-imagod-app stdout | local-imagod-app started
+local-imagod-app stdout | local-imagod-app started
 ```
 
 `--json` 指定時は JSON Lines で `log.line` が出力されます（`logs --json` は `command.summary` を出力しません）。

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cargo run -p imagod -- --config imagod.toml
 # ターミナル2
 cd examples/local-imagod
 # ターミナル1 で imagod が起動したことを確認してから実行
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-app --tail 200
 ```
 

--- a/crates/imago-cli/src/cli.rs
+++ b/crates/imago-cli/src/cli.rs
@@ -71,6 +71,10 @@ pub struct DeployArgs {
     /// Target name defined in imago.toml [target.<name>].
     #[arg(long, value_name = "TARGET_NAME")]
     pub target: Option<String>,
+
+    /// Return immediately after deploy succeeds without following logs.
+    #[arg(short = 'd', long)]
+    pub detach: bool,
 }
 
 /// Start a deployed service.
@@ -83,6 +87,10 @@ pub struct RunArgs {
     /// Target name defined in imago.toml [target.<name>].
     #[arg(long, value_name = "TARGET_NAME")]
     pub target: Option<String>,
+
+    /// Return immediately after run succeeds without following logs.
+    #[arg(short = 'd', long)]
+    pub detach: bool,
 }
 
 /// Stop a running service.
@@ -179,7 +187,7 @@ pub struct ComposeLogsArgs {
     pub name: Option<String>,
 
     /// Keep streaming logs until interrupted.
-    #[arg(long)]
+    #[arg(short = 'f', long)]
     pub follow: bool,
 
     /// Number of recent log lines to fetch before streaming.
@@ -207,7 +215,7 @@ pub struct LogsArgs {
     pub name: Option<String>,
 
     /// Keep streaming logs until interrupted.
-    #[arg(long)]
+    #[arg(short = 'f', long)]
     pub follow: bool,
 
     /// Number of recent log lines to fetch before streaming.
@@ -409,7 +417,10 @@ mod tests {
             cli,
             Cli {
                 json: false,
-                command: Commands::Deploy(DeployArgs { target: None }),
+                command: Commands::Deploy(DeployArgs {
+                    target: None,
+                    detach: false,
+                }),
             }
         );
     }
@@ -432,6 +443,23 @@ mod tests {
                 json: false,
                 command: Commands::Deploy(DeployArgs {
                     target: Some("default".to_string()),
+                    detach: false,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_deploy_with_detach() {
+        let cli = Cli::try_parse_from(["imago", "deploy", "-d"]).expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                json: false,
+                command: Commands::Deploy(DeployArgs {
+                    target: None,
+                    detach: true,
                 }),
             }
         );
@@ -557,6 +585,36 @@ mod tests {
     }
 
     #[test]
+    fn parses_compose_logs_with_short_follow_flag() {
+        let cli = Cli::try_parse_from([
+            "imago",
+            "compose",
+            "logs",
+            "nanokvm-mini",
+            "--target",
+            "nanokvm-cube",
+            "-f",
+        ])
+        .expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                json: false,
+                command: Commands::Compose(ComposeSubcommandArgs {
+                    command: ComposeCommands::Logs(ComposeLogsArgs {
+                        profile: "nanokvm-mini".to_string(),
+                        target: "nanokvm-cube".to_string(),
+                        name: None,
+                        follow: true,
+                        tail: 200,
+                    }),
+                }),
+            }
+        );
+    }
+
+    #[test]
     fn compose_logs_requires_target() {
         let err = Cli::try_parse_from(["imago", "compose", "logs", "nanokvm-mini"])
             .expect_err("parse should fail");
@@ -624,6 +682,7 @@ mod tests {
                 command: Commands::Run(RunArgs {
                     name: None,
                     target: None,
+                    detach: false,
                 }),
             }
         );
@@ -641,6 +700,25 @@ mod tests {
                 command: Commands::Run(RunArgs {
                     name: Some("svc-a".to_string()),
                     target: Some("edge".to_string()),
+                    detach: false,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_run_with_detach() {
+        let cli = Cli::try_parse_from(["imago", "run", "svc-a", "--detach"])
+            .expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                json: false,
+                command: Commands::Run(RunArgs {
+                    name: Some("svc-a".to_string()),
+                    target: None,
+                    detach: true,
                 }),
             }
         );
@@ -739,6 +817,24 @@ mod tests {
                     name: Some("svc-a".to_string()),
                     follow: true,
                     tail: 50,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_logs_with_short_follow_flag() {
+        let cli =
+            Cli::try_parse_from(["imago", "logs", "svc-a", "-f"]).expect("parse should succeed");
+
+        assert_eq!(
+            cli,
+            Cli {
+                json: false,
+                command: Commands::Logs(LogsArgs {
+                    name: Some("svc-a".to_string()),
+                    follow: true,
+                    tail: 200,
                 }),
             }
         );
@@ -932,6 +1028,7 @@ mod tests {
 
         assert!(help.contains("--target <TARGET_NAME>"));
         assert!(help.contains("Target name defined in imago.toml [target.<name>]"));
+        assert!(help.contains("-d, --detach"));
     }
 
     #[test]
@@ -941,7 +1038,7 @@ mod tests {
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
         let help = err.to_string();
 
-        assert!(help.contains("--follow"));
+        assert!(help.contains("-f, --follow"));
         assert!(help.contains("Keep streaming logs until interrupted"));
         assert!(help.contains("--tail <N>"));
         assert!(help.contains("Number of recent log lines to fetch before streaming"));

--- a/crates/imago-cli/src/commands/compose/mod.rs
+++ b/crates/imago-cli/src/commands/compose/mod.rs
@@ -439,6 +439,7 @@ async fn run_compose_deploy(args: ComposeDeployArgs, project_root: &Path) -> any
         let deploy_result = deploy::run_with_project_root_and_target_override(
             DeployArgs {
                 target: Some(args.target.clone()),
+                detach: true,
             },
             &service_project_root,
             Some(&target),

--- a/crates/imago-cli/src/commands/deploy/mod.rs
+++ b/crates/imago-cli/src/commands/deploy/mod.rs
@@ -40,9 +40,9 @@ use uuid::Uuid;
 use web_transport_quinn::{Session, proto::ConnectRequest};
 
 use crate::{
-    cli::DeployArgs,
+    cli::{DeployArgs, LogsArgs},
     commands::{
-        CommandResult, build, command_common, error_diagnostics,
+        CommandResult, build, command_common, error_diagnostics, logs,
         shared::dependency::{DependencyResolver, StandardDependencyResolver},
         ui,
     },
@@ -80,6 +80,7 @@ const IMAGO_DIR_NAME: &str = ".imago";
 const KNOWN_HOSTS_FILE_NAME: &str = "known_hosts";
 const DETAIL_WASM_STDOUT: &str = "wasm.stdout";
 const DETAIL_WASM_STDERR: &str = "wasm.stderr";
+const AUTO_FOLLOW_TAIL_LINES: u32 = 200;
 #[cfg(unix)]
 const IMAGO_DIR_MODE: u32 = 0o700;
 #[cfg(unix)]
@@ -434,14 +435,12 @@ async fn run_async_with_target_override(
     project_root: &Path,
     target_override: Option<&build::TargetConfig>,
 ) -> anyhow::Result<()> {
+    let DeployArgs { target, detach } = args;
     let dependency_resolver = StandardDependencyResolver;
     let target_connector = network::QuinnTargetConnector;
     let artifact_bundler = artifact::TarArtifactBundler;
 
-    let target_name = args
-        .target
-        .clone()
-        .unwrap_or_else(|| build::default_target_name().to_string());
+    let target_name = target.unwrap_or_else(|| build::default_target_name().to_string());
     let service_name =
         build::load_service_name(project_root).unwrap_or_else(|_| "<unknown>".to_string());
     let context_target = match target_override {
@@ -491,6 +490,7 @@ async fn run_async_with_target_override(
     let dependency_component_sources = dependency_resolver
         .resolve_dependency_component_sources(project_root, &manifest.dependencies)?;
 
+    let target_config_for_logs = build_output.target.clone();
     let target = build_output
         .target
         .require_deploy_credentials()
@@ -596,7 +596,13 @@ async fn run_async_with_target_override(
     let terminal =
         terminal.ok_or_else(|| anyhow!("command.event terminal event was not received"))?;
     match terminal.event_type {
-        CommandEventType::Succeeded => Ok(()),
+        CommandEventType::Succeeded => {
+            if !detach {
+                follow_logs_after_deploy(project_root, &target_config_for_logs, &manifest.name)
+                    .await;
+            }
+            Ok(())
+        }
         CommandEventType::Failed => {
             if let Some(err) = terminal.error {
                 Err(anyhow!(
@@ -609,6 +615,32 @@ async fn run_async_with_target_override(
         }
         CommandEventType::Canceled => Err(anyhow!("deploy was canceled")),
         _ => Err(anyhow!("unexpected terminal event")),
+    }
+}
+
+async fn follow_logs_after_deploy(
+    project_root: &Path,
+    target_config: &build::TargetConfig,
+    service_name: &str,
+) {
+    let logs_result = logs::run_with_project_root_and_target_override(
+        LogsArgs {
+            name: Some(service_name.to_string()),
+            follow: true,
+            tail: AUTO_FOLLOW_TAIL_LINES,
+        },
+        project_root,
+        Some(target_config),
+    )
+    .await;
+    if logs_result.exit_code != 0 {
+        let detail = logs_result
+            .stderr
+            .unwrap_or_else(|| format!("exit code {}", logs_result.exit_code));
+        ui::command_warn(
+            "deploy",
+            &format!("logs --follow failed after deploy succeeded: {detail}"),
+        );
     }
 }
 
@@ -2338,7 +2370,14 @@ mod tests {
             std::env::temp_dir().join(format!("imago-cli-deploy-run-fail-{}", Uuid::new_v4()));
         fs::create_dir_all(&root).expect("temp dir should be created");
 
-        let result = run_with_project_root(DeployArgs { target: None }, &root).await;
+        let result = run_with_project_root(
+            DeployArgs {
+                target: None,
+                detach: false,
+            },
+            &root,
+        )
+        .await;
 
         assert_eq!(result.exit_code, 2);
         let stderr = result.stderr.expect("stderr should be present");

--- a/crates/imago-cli/src/commands/logs/mod.rs
+++ b/crates/imago-cli/src/commands/logs/mod.rs
@@ -741,12 +741,7 @@ fn format_structured_bytes(
     let mut segment_start = 0usize;
     while segment_start < bytes.len() {
         if at_line_start {
-            let prefix = format!(
-                "{} {} {} | ",
-                current_timestamp_unix_secs(),
-                name,
-                stream_kind_label(stream_kind)
-            );
+            let prefix = format!("{} {} | ", name, stream_kind_label(stream_kind));
             let prefix_bytes = prefix.as_bytes();
             out.reserve(bytes.len().saturating_add(prefix_bytes.len()));
             out.extend_from_slice(prefix_bytes);
@@ -832,8 +827,8 @@ mod tests {
         let (rendered, at_line_start) =
             format_structured_bytes("svc-a", LogStreamKind::Stdout, b"a\nb\n", true);
         let rendered_text = String::from_utf8_lossy(&rendered);
-        assert!(rendered_text.contains(" svc-a stdout | a\n"));
-        assert!(rendered_text.contains(" svc-a stdout | b\n"));
+        assert!(rendered_text.contains("svc-a stdout | a\n"));
+        assert!(rendered_text.contains("svc-a stdout | b\n"));
         assert!(at_line_start);
     }
 
@@ -860,7 +855,7 @@ mod tests {
 
         let first_rendered = renderable_chunk_bytes(&first, true, &mut prefix_state).into_owned();
         let first_text = String::from_utf8_lossy(&first_rendered);
-        assert!(first_text.contains(" svc-a stdout | hel"));
+        assert!(first_text.contains("svc-a stdout | hel"));
         assert_eq!(
             renderable_chunk_bytes(&second, true, &mut prefix_state).as_ref(),
             b"lo\n"
@@ -890,7 +885,7 @@ mod tests {
 
         let first_rendered = renderable_chunk_bytes(&first, false, &mut prefix_state).into_owned();
         let first_prefix_text = String::from_utf8_lossy(&first_rendered);
-        assert!(first_prefix_text.contains(" svc-a stdout | "));
+        assert!(first_prefix_text.contains("svc-a stdout | "));
         assert!(first_rendered.ends_with(&[0xe3, 0x81]));
         assert_eq!(
             renderable_chunk_bytes(&second, false, &mut prefix_state).as_ref(),

--- a/crates/imago-cli/src/commands/run.rs
+++ b/crates/imago-cli/src/commands/run.rs
@@ -5,16 +5,18 @@ use imago_protocol::{CommandPayload, CommandType, RunCommandPayload};
 use uuid::Uuid;
 
 use crate::{
-    cli::RunArgs,
+    cli::{LogsArgs, RunArgs},
     commands::{
         CommandResult, build,
         command_common::{
             format_local_context_line, format_peer_context_line, handle_terminal_event,
             negotiate_hello, resolve_service_name,
         },
-        deploy, error_diagnostics, ui,
+        deploy, error_diagnostics, logs, ui,
     },
 };
+
+const AUTO_FOLLOW_TAIL_LINES: u32 = 200;
 
 pub async fn run(args: RunArgs) -> CommandResult {
     run_with_project_root(args, Path::new(".")).await
@@ -38,16 +40,19 @@ pub(crate) async fn run_with_project_root(args: RunArgs, project_root: &Path) ->
 }
 
 async fn run_async(args: RunArgs, project_root: &Path) -> anyhow::Result<()> {
+    let RunArgs {
+        name,
+        target,
+        detach,
+    } = args;
     ui::command_stage("run", "load-config", "loading target configuration");
-    let target_name = args
-        .target
-        .clone()
-        .unwrap_or_else(|| build::default_target_name().to_string());
-    let target = build::load_target_config(&target_name, project_root)
-        .context("failed to load target configuration")?
+    let target_name = target.unwrap_or_else(|| build::default_target_name().to_string());
+    let target_config = build::load_target_config(&target_name, project_root)
+        .context("failed to load target configuration")?;
+    let target = target_config
         .require_deploy_credentials()
         .context("target settings are invalid for run")?;
-    let service_name = resolve_service_name(args.name.as_deref(), project_root)
+    let service_name = resolve_service_name(name.as_deref(), project_root)
         .context("failed to resolve service name for run")?;
     ui::command_info(
         "run",
@@ -81,7 +86,9 @@ async fn run_async(args: RunArgs, project_root: &Path) -> anyhow::Result<()> {
         correlation_id,
         Uuid::new_v4(),
         CommandType::Run,
-        CommandPayload::Run(RunCommandPayload { name: service_name }),
+        CommandPayload::Run(RunCommandPayload {
+            name: service_name.clone(),
+        }),
     )?;
     let responses = deploy::request_command_start_events_with_timeout(
         &connected.session,
@@ -89,7 +96,37 @@ async fn run_async(args: RunArgs, project_root: &Path) -> anyhow::Result<()> {
         command_stream_timeout,
     )
     .await?;
-    handle_terminal_event("run", responses)
+    handle_terminal_event("run", responses)?;
+    if !detach {
+        follow_logs_after_run(project_root, &target_config, &service_name).await;
+    }
+    Ok(())
+}
+
+async fn follow_logs_after_run(
+    project_root: &Path,
+    target_config: &build::TargetConfig,
+    service_name: &str,
+) {
+    let logs_result = logs::run_with_project_root_and_target_override(
+        LogsArgs {
+            name: Some(service_name.to_string()),
+            follow: true,
+            tail: AUTO_FOLLOW_TAIL_LINES,
+        },
+        project_root,
+        Some(target_config),
+    )
+    .await;
+    if logs_result.exit_code != 0 {
+        let detail = logs_result
+            .stderr
+            .unwrap_or_else(|| format!("exit code {}", logs_result.exit_code));
+        ui::command_warn(
+            "run",
+            &format!("logs --follow failed after run succeeded: {detail}"),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/imago-cli/src/main.rs
+++ b/crates/imago-cli/src/main.rs
@@ -193,7 +193,10 @@ mod tests {
         let result = dispatch_with_project_root_async(
             Cli {
                 json: false,
-                command: Commands::Deploy(DeployArgs { target: None }),
+                command: Commands::Deploy(DeployArgs {
+                    target: None,
+                    detach: false,
+                }),
             },
             &root,
         )
@@ -213,6 +216,7 @@ mod tests {
                 command: Commands::Run(RunArgs {
                     name: None,
                     target: None,
+                    detach: false,
                 }),
             },
             &root,

--- a/docs/spec/cli-output.md
+++ b/docs/spec/cli-output.md
@@ -138,3 +138,11 @@ CLI は起動時に 1 つの出力モードを選ぶ。
 
 - `ps` / `compose ps` は `started_at` 表示を `chrono` ベースのローカル時刻変換へ更新した。
 - `state=stopped` で `started_at` が空文字または `"0"` の場合、table/JSON ともに `"-"` を表示する契約を追加した。
+
+## 12. 実装反映ノート（run/deploy 自動 logs follow + detach / 2026-02-25）
+
+- `run` / `deploy` は成功時に対象サービスの `logs --follow` を既定で開始する。`-d` / `--detach` 指定時は自動追従を行わず即時終了する。
+- 自動追従で `logs` が失敗しても、`run` / `deploy` 自体は成功扱いを維持し、`Rich` / `Plain` では警告のみ表示する。
+- `logs` / `compose logs` は `-f` を `--follow` の短縮オプションとして受理する。
+- Textログの prefix から timestamp を削除し、`<service> <stream> | <log>` 形式へ統一した。
+- `logs --json` の `log.line.timestamp` は従来どおり維持する。

--- a/examples/local-imagod-http/README.md
+++ b/examples/local-imagod-http/README.md
@@ -20,7 +20,7 @@ cargo run -p imagod -- --config imagod.toml
 # ターミナル2
 cd examples/local-imagod-http
 # ターミナル1 で imagod が起動したことを確認してから実行
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-http-app --tail 200
 ```
 

--- a/examples/local-imagod-plugin-hello/README.md
+++ b/examples/local-imagod-plugin-hello/README.md
@@ -20,7 +20,7 @@ cargo run -p imagod -- --config "$(pwd)/imagod.toml"
 
 ```bash
 cd examples/local-imagod-plugin-hello
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-plugin-hello-app --tail 200
 ```
 

--- a/examples/local-imagod-plugin-native-admin/README.md
+++ b/examples/local-imagod-plugin-native-admin/README.md
@@ -20,7 +20,7 @@ cargo run -p imagod -- --config "$(pwd)/imagod.toml"
 
 ```bash
 cd examples/local-imagod-plugin-native-admin
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-plugin-native-admin-app --tail 200
 ```
 

--- a/examples/local-imagod-socket/README.md
+++ b/examples/local-imagod-socket/README.md
@@ -20,7 +20,7 @@ cargo run -p imagod -- --config imagod.toml
 # ターミナル2
 cd examples/local-imagod-socket
 # ターミナル1 で imagod が起動したことを確認してから実行
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-socket-app --tail 200
 ```
 

--- a/examples/local-imagod/README.md
+++ b/examples/local-imagod/README.md
@@ -20,7 +20,7 @@ cargo run -p imagod -- --config imagod.toml
 # ターミナル2
 cd examples/local-imagod
 # ターミナル1 で imagod が起動したことを確認してから実行
-cargo run -p imago-cli -- deploy --target default
+cargo run -p imago-cli -- deploy --target default --detach
 cargo run -p imago-cli -- logs local-imagod-app --tail 200
 ```
 

--- a/tests/e2e_cli_deploy_failure.rs
+++ b/tests/e2e_cli_deploy_failure.rs
@@ -68,8 +68,10 @@ fn e2e_cli_deploy_failure_includes_wasm_logs() -> TestResult {
     let mut deploy_failed = None;
     let mut last_output = None;
     for _attempt in 1..=DEPLOY_FAIL_MAX_ATTEMPTS {
-        let output =
-            scenario.run_service_cli(service.name(), &["deploy", "--target", "default"])?;
+        let output = scenario.run_service_cli(
+            service.name(),
+            &["deploy", "--target", "default", "--detach"],
+        )?;
         if !output.success {
             deploy_failed = Some(output);
             break;

--- a/tests/e2e_helper/scenario.rs
+++ b/tests/e2e_helper/scenario.rs
@@ -174,7 +174,7 @@ impl Scenario {
     pub fn deploy_service(&self, service_name: &str, target: &str) -> TestResult<CmdOutput> {
         let service = self.service(service_name)?;
         ensure_target_exists(service, target)?;
-        let args = ["deploy", "--target", target];
+        let args = ["deploy", "--target", target, "--detach"];
         let output = self.run_service_cli(service_name, &args)?;
         output.ensure_success(&args)?;
         Ok(output)

--- a/tests/e2e_rpc.rs
+++ b/tests/e2e_rpc.rs
@@ -71,7 +71,7 @@ fn e2e_rpc_two_nodes_cert_flow() -> TestResult {
         &workspace_root,
         &greeter_dir,
         &control_home,
-        &["deploy", "--target", "default"],
+        &["deploy", "--target", "default", "--detach"],
     )?;
     ensure_success("rpc-greeter deploy", &deploy_greeter)?;
     assert_command_completed("rpc-greeter deploy", &deploy_greeter)?;
@@ -83,7 +83,7 @@ fn e2e_rpc_two_nodes_cert_flow() -> TestResult {
         &workspace_root,
         &client_dir,
         &control_home,
-        &["deploy", "--target", "default"],
+        &["deploy", "--target", "default", "--detach"],
     )?;
     ensure_success("cli-client deploy", &deploy_client)?;
     assert_command_completed("cli-client deploy", &deploy_client)?;

--- a/tests/e2e_rpc_single.rs
+++ b/tests/e2e_rpc_single.rs
@@ -62,7 +62,7 @@ fn e2e_rpc_single_node_local_flow() -> TestResult {
         &workspace_root,
         &greeter_dir,
         &control_home,
-        &["deploy", "--target", "default"],
+        &["deploy", "--target", "default", "--detach"],
     )?;
     ensure_success("rpc-greeter deploy", &deploy_greeter)?;
     assert_command_completed("rpc-greeter deploy", &deploy_greeter)?;
@@ -74,7 +74,7 @@ fn e2e_rpc_single_node_local_flow() -> TestResult {
         &workspace_root,
         &client_dir,
         &control_home,
-        &["deploy", "--target", "default"],
+        &["deploy", "--target", "default", "--detach"],
     )?;
     ensure_success("rpc-caller deploy", &deploy_client)?;
     assert_command_completed("rpc-caller deploy", &deploy_client)?;


### PR DESCRIPTION
## Motivation
- `imago run` / `imago deploy` completed successfully but then exited immediately, requiring a separate `logs --follow` command to inspect runtime behavior.
- Operators also needed a short `-f` alias for log following, and text logs were noisier than necessary due to timestamp prefixes.

## Summary
- Added `-d/--detach` to `run` and `deploy` CLI args, and changed successful default behavior to auto-start log following for only the target service.
- Kept command success semantics when auto-follow setup fails by emitting warnings without failing the parent `run`/`deploy` command.
- Moved `ui::command_finish("run"|"deploy", ...)` to after auto-follow completes so command lifetime matches actual behavior.
- Added `-f` short alias for both `logs` and `compose logs` follow options.
- Removed timestamp prefix insertion from text log formatting while keeping JSON `log.line.timestamp` intact.
- Ensured `compose deploy` stays non-blocking by forcing internal deploy calls to `detach=true`.
- Updated CLI/tests/e2e callsites and docs (`docs/spec/cli-output.md`, `README.md`, `QUICKSTART.md`, and local-imagod example READMEs) to reflect the new defaults and `--detach` usage.

## Validation
- `cargo fmt --all` (before checks): passed
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`: passed
- `RUSTC_WRAPPER= cargo test --workspace`: passed
- `cargo fmt --all` (final pre-commit pass): passed
