### PR TITLE
Disable macOS e2e matrix in CI workflow

### DIFF
--- a/.github/workflows/ci-rust-e2e.yml
+++ b/.github/workflows/ci-rust-e2e.yml
@@ -23,8 +23,9 @@ jobs:
         include:
           - name: ubuntu
             runs_on: imago-default-runner-set
-          - name: macos
-            runs_on: macos-latest
+          # Disabled on 2026-02-25 by request: macOS e2e is temporarily turned off.
+          # - name: macos
+          #   runs_on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- `ci-rust-e2e` の macOS 実行を一時的に止める要件があり、Linux 実行のみを維持するため。
- matrix から macOS を削除せずコメントとして残し、再有効化時の差分を最小化するため。

## Summary
- `.github/workflows/ci-rust-e2e.yml` の `strategy.matrix.include` で macOS エントリをコメントアウト。
- 直前に理由コメントを追加。
  - `# Disabled on 2026-02-25 by request: macOS e2e is temporarily turned off.`
- ubuntu エントリおよび他のジョブステップは変更なし。
- 設計/仕様（`docs/spec/`）の更新は不要（CI 実行マトリクスのみ変更）。

## Validation
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ⚠️ (`sccache: Operation not permitted` のため失敗)
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all` (final pass) ✅
