### PR TITLE
ci: run cargo-deny checks without Docker

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -16,18 +16,23 @@ concurrency:
 jobs:
   checks:
     name: checks
-    runs-on: imago-dind-runner-set
+    runs-on: imago-default-runner-set
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: cargo deny (blocking)
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          rust-version: stable
-          manifest-path: ./Cargo.toml
-          command: check bans licenses sources
-          arguments: --workspace
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Rust cache
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+
+      - name: cargo deny checks
+        run: cargo deny --workspace check bans licenses sources
 
   advisories:
     name: advisories


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- `cargo-deny` の `checks` ジョブが `EmbarkStudios/cargo-deny-action@v2` (Docker 実行) に依存しており、実行コストが重かったため。
- 既存の `imago-default-runner-set` で直接 `cargo deny` を実行する構成に統一し、Docker 依存をなくしてCI実行を軽量化するため。

## Summary
- `.github/workflows/cargo-deny.yaml` の `checks` ジョブを `imago-dind-runner-set` から `imago-default-runner-set` へ変更。
- `checks` ジョブの `EmbarkStudios/cargo-deny-action@v2` を削除し、以下へ置換。
  - `dtolnay/rust-toolchain@stable`
  - `Swatinem/rust-cache@v2` (`runner.environment != 'self-hosted'` 条件)
  - `taiki-e/install-action@cargo-deny`
  - `cargo deny --workspace check bans licenses sources`
- `advisories` ジョブ (`continue-on-error: true` と `cargo deny ... advisories --disable-fetch`) は変更なし。
- プロトコル/ランタイム仕様変更はないため `docs/spec/` 更新は不要。

## Validation
- `cargo fmt --all`
  - 成功
- `cargo clippy --workspace --all-targets -- -D warnings`
  - 成功
- `cargo test --workspace`
  - 成功（workspace 全体のテスト・doc test がpass）
- `rg -n "EmbarkStudios/cargo-deny-action|imago-dind-runner-set" .github/workflows`
  - ヒットなし（Docker action / dind runner 参照が workflow から除去済み）
- `DOCKER_HOST=ssh://sizumita@ssh.smdr.io act pull_request -W .github/workflows/cargo-deny.yaml -j checks --dryrun -P imago-default-runner-set=ghcr.io/catthehacker/ubuntu:full-latest`
  - 成功（`cargo-deny/checks` dry-run が `Job succeeded`）
