### PR TITLE
Add workflow to cancel pull request runs on close

### DIFF
--- a/.github/workflows/cancel-runs-on-pr-close.yml
+++ b/.github/workflows/cancel-runs-on-pr-close.yml
@@ -1,0 +1,62 @@
+name: cancel-runs-on-pr-close
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cancel-runs-on-pr-close-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  cancel:
+    name: cancel runs for closed pull request
+    runs-on: imago-dind-runner-set
+    steps:
+      - name: Cancel queued and running pull_request runs for this PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const statuses = ["queued", "in_progress"];
+            const runs = [];
+
+            for (const status of statuses) {
+              const listed = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                {
+                  owner,
+                  repo,
+                  event: "pull_request",
+                  status,
+                  per_page: 100,
+                },
+                (response) => response.data.workflow_runs
+              );
+              runs.push(...listed);
+            }
+
+            const targets = runs.filter((run) => {
+              if (run.id === context.runId) {
+                return false;
+              }
+
+              return run.pull_requests?.some((pr) => pr.number === prNumber) ?? false;
+            });
+
+            core.info(`Found ${targets.length} run(s) to cancel for PR #${prNumber}.`);
+
+            for (const run of targets) {
+              core.info(`Cancel run_id=${run.id} status=${run.status} name=${run.name}`);
+              await github.rest.actions.cancelWorkflowRun({
+                owner,
+                repo,
+                run_id: run.id,
+              });
+            }


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- Pull request を close した後も、同一 PR に紐づく `pull_request` workflow run が継続するケースがあり、CI リソースを消費し続ける。
- close 済み PR に対する不要な run を早期停止し、無関係 run の誤停止を避けつつ CI キュー負荷を下げる必要がある。

## Summary
- `.github/workflows/cancel-runs-on-pr-close.yml` を新規追加。
- `pull_request` の `closed` をトリガーに起動し、`actions: write` 権限で当該 PR に紐づく `queued` / `in_progress` の `pull_request` run を列挙して `cancelWorkflowRun` を実行。
- 対象判定は `run.pull_requests` 内の PR 番号一致のみとし、`run.id !== context.runId` で自己キャンセルを回避。
- `force-cancel` や `pull_request_target` は採用せず、影響範囲を最小化。
- Rust コード、CLI、protocol、`docs/spec/` の変更はなし。

## Validation
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅
  - workspace tests/doc-tests ともに失敗なし
- `cargo fmt --all` (final pass) ✅
