### PR TITLE
Follow up plain error marker contract checks for e2e CLI output

### DIFF
--- a/tests/e2e_cli_deploy_failure.rs
+++ b/tests/e2e_cli_deploy_failure.rs
@@ -131,3 +131,30 @@ fn assert_deploy_failure_includes_wasm_logs(label: &str, output: &CmdOutput) -> 
 
     Ok(())
 }
+
+#[test]
+fn has_command_error_requires_error_marker() {
+    let output = CmdOutput {
+        status: "exit status: 1".to_string(),
+        status_code: Some(1),
+        success: false,
+        stdout: String::new(),
+        stderr: "deployment failed without marker".to_string(),
+        combined: "deployment failed without marker".to_string(),
+    };
+
+    assert!(
+        !output.has_command_error(),
+        "non-empty stderr without [error] marker must not set command error contract"
+    );
+    assert_eq!(
+        output.command_summary_error(),
+        None,
+        "summary error must only come from [error] markers"
+    );
+    assert_eq!(
+        output.command_error_messages(),
+        vec!["deployment failed without marker".to_string()],
+        "diagnostic fallback should remain available in command_error_messages"
+    );
+}

--- a/tests/e2e_helper/cli.rs
+++ b/tests/e2e_helper/cli.rs
@@ -35,16 +35,21 @@ impl CmdOutput {
     }
 
     pub fn command_summary_error(&self) -> Option<String> {
-        self.command_error_messages().into_iter().last()
+        self.plain_command_error_messages().into_iter().last()
     }
 
     pub fn has_command_error(&self) -> bool {
-        !self.command_error_messages().is_empty()
+        !self.plain_command_error_messages().is_empty()
+    }
+
+    fn plain_command_error_messages(&self) -> Vec<String> {
+        let mut messages = collect_plain_error_messages(&self.stdout);
+        messages.extend(collect_plain_error_messages(&self.stderr));
+        messages
     }
 
     pub fn command_error_messages(&self) -> Vec<String> {
-        let mut messages = collect_plain_error_messages(&self.stdout);
-        messages.extend(collect_plain_error_messages(&self.stderr));
+        let mut messages = self.plain_command_error_messages();
         if messages.is_empty() {
             let fallback = self.stderr.trim();
             if !fallback.is_empty() {


### PR DESCRIPTION
### Motivation
- E2E helper logic treated any non-empty `stderr` as a command error which weakens the plain-output contract and can hide regressions that drop explicit `[error] ...` markers.

### Description
- Updated `CmdOutput::command_summary_error()` and `CmdOutput::has_command_error()` in `tests/e2e_helper/cli.rs` to rely on marker-only extraction via a new `plain_command_error_messages()` helper.
- Added `plain_command_error_messages()` which collects only `[error]`-prefixed messages from `stdout` and `stderr` without falling back to generic `stderr` text.
- Kept diagnostic fallback behavior in `command_error_messages()` so callers can still obtain raw `stderr` when no markers are present.
- Added regression test `has_command_error_requires_error_marker` in `tests/e2e_cli_deploy_failure.rs` to assert that non-empty `stderr` without an `[error]` marker does not satisfy the command-error contract while `command_error_messages()` still returns the fallback diagnostic.

### Testing
- Ran `cargo fmt --all` which succeeded.
- Ran `cargo test -p imago --features e2e --test e2e_cli_deploy_failure has_command_error_requires_error_marker` which could not complete in this environment because the `wasm32-wasip2` target required by the build script is not installed (build error referencing `core`/`wasm32-wasip2`).
- Performed `curl -I https://doc.rust-lang.org/rustc/platform-support/wasm32-wasip2.html | head -n 5` as an automated check which returned HTTP 200 OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f311027bc83339c2c2768c3a068e0)