### PR TITLE
Add GitHub issue form templates for bug and feature reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a reproducible defect in imago.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide enough detail for us to reproduce and verify the fix.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A concise description of the bug.
+      placeholder: Describe the unexpected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact commands, inputs, and environment details.
+      placeholder: |
+        1. Run ...
+        2. Deploy ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened, including logs or error messages.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: imago / imagod version (or commit SHA).
+      placeholder: v0.0.0 or abc1234
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target environment
+      description: Choose the environment where the issue occurs.
+      options:
+        - local-imagod example
+        - embedded Linux target
+        - CI
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, screenshots, or other context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/yieldspace/imago/tree/main/docs
+    about: Read the guides and references before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Propose an improvement to imago.
+title: "[feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: Describe the limitation or pain point.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the expected behavior or API shape.
+      placeholder: Outline your preferred solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternatives or trade-offs you evaluated.
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Resource impact
+      description: Expected CPU, memory, or binary-size impact for embedded targets.
+      placeholder: Note if impact is unknown.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I checked for similar existing issues.
+          required: true


### PR DESCRIPTION
### Motivation
- Provide structured issue intake so reporters include reproducible details for bugs and meaningful context for feature requests.
- Improve triage speed and capture embedded-target constraints (CPU/memory/binary-size) up-front for this embedded-focused project.

### Description
- Added `.github/ISSUE_TEMPLATE/bug_report.yml` with required fields for summary, steps to reproduce, expected/actual behavior, version, target environment, and additional context.
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` with required problem/proposal fields, an impact field for resource constraints, and a short checklist.
- Added `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and add a documentation contact link.
- No changes to runtime, protocol, or crate code were made.

### Testing
- Ran `git diff --check` which returned clean results and reported no whitespace errors; the command succeeded.
- Verified new files are present via `git status --short` and committed them with `git commit`, which succeeded and created a commit with the three new files.
- Performed a quick documentation lookup with `curl` to confirm issue-form syntax references; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a11b09282c83338db47b3d27fa3b7d)