### PR TITLE
Optimize IPC decode and invoke payload ownership path (#229)

### DIFF
--- a/crates/imagod-control/src/orchestrator.rs
+++ b/crates/imagod-control/src/orchestrator.rs
@@ -468,7 +468,7 @@ impl Orchestrator {
         target_service_name: &str,
         interface_id: &str,
         function: &str,
-        args_cbor: &[u8],
+        args_cbor: Vec<u8>,
     ) -> Result<Vec<u8>, ImagodError> {
         self.supervisor
             .invoke(target_service_name, interface_id, function, args_cbor)

--- a/crates/imagod-control/src/service_supervisor.rs
+++ b/crates/imagod-control/src/service_supervisor.rs
@@ -994,7 +994,7 @@ impl ServiceSupervisor {
         target_service_name: &str,
         interface_id: &str,
         function: &str,
-        payload_cbor: &[u8],
+        payload_cbor: Vec<u8>,
     ) -> Result<Vec<u8>, ImagodError> {
         let (runner_endpoint, invocation_secret) = {
             let inner = self.inner.read().await;
@@ -1032,7 +1032,7 @@ impl ServiceSupervisor {
             &RunnerInboundRequest::Invoke {
                 interface_id: interface_id.to_string(),
                 function: function.to_string(),
-                payload_cbor: payload_cbor.to_vec(),
+                payload_cbor,
                 token,
             },
         )
@@ -2908,7 +2908,7 @@ mod tests {
                 target_service_name,
                 "yieldspace:service/invoke",
                 "call",
-                b"",
+                Vec::new(),
             )
             .await
             .expect_err("not-ready target should be rejected");
@@ -2983,7 +2983,7 @@ mod tests {
                 target_service_name,
                 "yieldspace:service/invoke",
                 "call",
-                &payload,
+                payload.clone(),
             )
             .await
             .expect("invoke should succeed");

--- a/crates/imagod-control/src/service_supervisor/manager_control.rs
+++ b/crates/imagod-control/src/service_supervisor/manager_control.rs
@@ -290,7 +290,7 @@ pub(super) async fn handle_control_request_impl(
                 &target_service,
                 &interface_id,
                 &function,
-                &args_cbor,
+                args_cbor,
             )
             .await
             {

--- a/crates/imagod-control/src/service_supervisor/remote_rpc.rs
+++ b/crates/imagod-control/src/service_supervisor/remote_rpc.rs
@@ -114,7 +114,7 @@ impl RemoteRpcManager {
         target_service: &str,
         interface_id: &str,
         function: &str,
-        args_cbor: &[u8],
+        args_cbor: Vec<u8>,
     ) -> Result<Vec<u8>, ImagodError> {
         invoke_remote_authority(
             config_path,
@@ -197,7 +197,7 @@ async fn invoke_remote_authority(
     target_service: &str,
     interface_id: &str,
     function: &str,
-    args_cbor: &[u8],
+    args_cbor: Vec<u8>,
 ) -> Result<Vec<u8>, ImagodError> {
     let session = connect_remote_session(config_path, authority).await?;
     let correlation_id = Uuid::new_v4();
@@ -210,7 +210,7 @@ async fn invoke_remote_authority(
         &RpcInvokeRequest {
             interface_id: interface_id.to_string(),
             function: function.to_string(),
-            args_cbor: args_cbor.to_vec(),
+            args_cbor,
             target_service: RpcInvokeTargetService {
                 name: target_service.to_string(),
             },

--- a/crates/imagod-ipc/src/ipc/dbus_p2p.rs
+++ b/crates/imagod-ipc/src/ipc/dbus_p2p.rs
@@ -1,5 +1,6 @@
 //! DBus-like peer-to-peer transport backed by Unix domain sockets and CBOR frames.
 
+use std::any::Any;
 use std::path::Path;
 
 use imago_protocol::{ErrorCode, Validate};
@@ -44,7 +45,7 @@ impl DbusP2pTransport {
     /// Reads one length-prefixed CBOR message from a stream.
     pub async fn read_message<T>(stream: &mut UnixStream) -> Result<T, ImagodError>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned + 'static,
     {
         let bytes = read_frame(stream).await?;
         let message = imago_protocol::from_cbor::<T>(&bytes).map_err(|e| {
@@ -54,7 +55,7 @@ impl DbusP2pTransport {
                 format!("ipc message decode failed: {e}"),
             )
         })?;
-        validate_received_message::<T>(&bytes)?;
+        validate_received_message(&message)?;
         Ok(message)
     }
 
@@ -92,7 +93,7 @@ impl InvocationTransport for DbusP2pTransport {
 async fn call<Req, Resp>(endpoint: &Path, request: &Req) -> Result<Resp, ImagodError>
 where
     Req: Serialize,
-    Resp: DeserializeOwned,
+    Resp: DeserializeOwned + 'static,
 {
     let mut stream = UnixStream::connect(endpoint).await.map_err(|e| {
         ImagodError::new(
@@ -125,46 +126,27 @@ where
     })
 }
 
-fn validate_received_message<T>(bytes: &[u8]) -> Result<(), ImagodError>
+fn validate_received_message<T>(message: &T) -> Result<(), ImagodError>
 where
-    T: DeserializeOwned,
+    T: 'static,
 {
-    let message_type = std::any::type_name::<T>();
-
-    if message_type == std::any::type_name::<ControlRequest>() {
-        let message = decode_for_validation::<ControlRequest>(bytes)?;
-        return validate_message(&message);
+    if let Some(message) = (message as &dyn Any).downcast_ref::<ControlRequest>() {
+        return validate_message(message);
     }
 
-    if message_type == std::any::type_name::<ControlResponse>() {
-        let message = decode_for_validation::<ControlResponse>(bytes)?;
-        return validate_message(&message);
+    if let Some(message) = (message as &dyn Any).downcast_ref::<ControlResponse>() {
+        return validate_message(message);
     }
 
-    if message_type == std::any::type_name::<RunnerInboundRequest>() {
-        let message = decode_for_validation::<RunnerInboundRequest>(bytes)?;
-        return validate_message(&message);
+    if let Some(message) = (message as &dyn Any).downcast_ref::<RunnerInboundRequest>() {
+        return validate_message(message);
     }
 
-    if message_type == std::any::type_name::<RunnerInboundResponse>() {
-        let message = decode_for_validation::<RunnerInboundResponse>(bytes)?;
-        return validate_message(&message);
+    if let Some(message) = (message as &dyn Any).downcast_ref::<RunnerInboundResponse>() {
+        return validate_message(message);
     }
 
     Ok(())
-}
-
-fn decode_for_validation<T>(bytes: &[u8]) -> Result<T, ImagodError>
-where
-    T: DeserializeOwned,
-{
-    imago_protocol::from_cbor(bytes).map_err(|e| {
-        ImagodError::new(
-            ErrorCode::BadRequest,
-            STAGE,
-            format!("ipc message decode failed: {e}"),
-        )
-    })
 }
 
 /// Writes one big-endian length-prefixed frame.
@@ -239,6 +221,8 @@ async fn read_frame(stream: &mut UnixStream) -> Result<Vec<u8>, ImagodError> {
 
 #[cfg(test)]
 mod tests {
+    use std::{hint::black_box, time::Instant};
+
     use tokio::io::AsyncWriteExt;
     use tokio::net::UnixListener;
     use tokio::net::UnixStream;
@@ -247,6 +231,36 @@ mod tests {
     use crate::ipc::{
         ControlRequest, ControlResponse, RunnerInboundRequest, RunnerInboundResponse,
     };
+
+    fn p95_micros(samples: &mut [u128]) -> u128 {
+        assert!(!samples.is_empty(), "samples must not be empty");
+        samples.sort_unstable();
+        let index = (samples.len() - 1) * 95 / 100;
+        samples[index]
+    }
+
+    fn decode_request(bytes: &[u8]) -> Result<RunnerInboundRequest, ImagodError> {
+        imago_protocol::from_cbor::<RunnerInboundRequest>(bytes).map_err(|e| {
+            ImagodError::new(
+                ErrorCode::BadRequest,
+                STAGE,
+                format!("ipc message decode failed: {e}"),
+            )
+        })
+    }
+
+    fn decode_then_validate_legacy(bytes: &[u8]) -> Result<RunnerInboundRequest, ImagodError> {
+        let message = decode_request(bytes)?;
+        let for_validation = decode_request(bytes)?;
+        validate_message(&for_validation)?;
+        Ok(message)
+    }
+
+    fn decode_then_validate_optimized(bytes: &[u8]) -> Result<RunnerInboundRequest, ImagodError> {
+        let message = decode_request(bytes)?;
+        validate_received_message(&message)?;
+        Ok(message)
+    }
 
     #[tokio::test]
     async fn call_control_round_trip() {
@@ -393,5 +407,44 @@ mod tests {
         assert_eq!(err.code, ErrorCode::BadRequest);
         assert_eq!(err.stage, STAGE);
         assert!(err.message.contains("validation failed"));
+    }
+
+    #[test]
+    #[ignore]
+    fn read_message_decode_perf_compare() {
+        const PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+        const ITERATIONS: usize = 64;
+        let request = RunnerInboundRequest::Invoke {
+            interface_id: "yieldspace:svc/invoke".to_string(),
+            function: "call".to_string(),
+            payload_cbor: vec![0xAB; PAYLOAD_BYTES],
+            token: "token-1".to_string(),
+        };
+        let encoded = imago_protocol::to_cbor(&request).expect("request should encode");
+
+        let mut legacy_samples = Vec::with_capacity(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            let started = Instant::now();
+            let decoded =
+                decode_then_validate_legacy(&encoded).expect("legacy decode should succeed");
+            black_box(decoded);
+            legacy_samples.push(started.elapsed().as_micros());
+        }
+
+        let mut optimized_samples = Vec::with_capacity(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            let started = Instant::now();
+            let decoded =
+                decode_then_validate_optimized(&encoded).expect("optimized decode should succeed");
+            black_box(decoded);
+            optimized_samples.push(started.elapsed().as_micros());
+        }
+
+        let legacy_p95 = p95_micros(&mut legacy_samples);
+        let optimized_p95 = p95_micros(&mut optimized_samples);
+        eprintln!(
+            "read_message_decode_perf_compare payload_bytes={} iterations={} optimized_p95_us={} legacy_p95_us={}",
+            PAYLOAD_BYTES, ITERATIONS, optimized_p95, legacy_p95
+        );
     }
 }

--- a/crates/imagod-runtime-wasmtime/src/plugin_resolver.rs
+++ b/crates/imagod-runtime-wasmtime/src/plugin_resolver.rs
@@ -626,7 +626,7 @@ fn register_binding_import_shims(
                         &target_service,
                         &interface_id,
                         &function_name,
-                        &args_cbor,
+                        args_cbor,
                     );
 
                     results[0] = match invoke_result {

--- a/crates/imagod-runtime-wasmtime/src/rpc_bridge.rs
+++ b/crates/imagod-runtime-wasmtime/src/rpc_bridge.rs
@@ -98,7 +98,7 @@ pub fn invoke_connection(
     target_service: &str,
     interface_id: &str,
     function: &str,
-    args_cbor: &[u8],
+    args_cbor: Vec<u8>,
 ) -> Result<Vec<u8>, String> {
     let connection = lookup_connection(connection_rep)
         .ok_or_else(|| format!("rpc connection {connection_rep} is not available"))?;
@@ -235,7 +235,7 @@ fn invoke_local_uds(
     target_service: &str,
     interface_id: &str,
     function: &str,
-    args_cbor: &[u8],
+    args_cbor: Vec<u8>,
 ) -> Result<Vec<u8>, String> {
     let manager_auth_proof =
         compute_manager_auth_proof(context.manager_auth_secret(), context.runner_id())
@@ -268,7 +268,7 @@ fn invoke_local_uds(
         &RunnerInboundRequest::Invoke {
             interface_id: interface_id.to_string(),
             function: function.to_string(),
-            payload_cbor: args_cbor.to_vec(),
+            payload_cbor: args_cbor,
             token,
         },
     )?;
@@ -288,7 +288,7 @@ fn invoke_remote_via_manager(
     target_service: &str,
     interface_id: &str,
     function: &str,
-    args_cbor: &[u8],
+    args_cbor: Vec<u8>,
 ) -> Result<Vec<u8>, String> {
     let manager_auth_proof =
         compute_manager_auth_proof(context.manager_auth_secret(), context.runner_id())
@@ -302,7 +302,7 @@ fn invoke_remote_via_manager(
             target_service: target_service.to_string(),
             interface_id: interface_id.to_string(),
             function: function.to_string(),
-            args_cbor: args_cbor.to_vec(),
+            args_cbor,
         },
     )?;
     match response {
@@ -448,7 +448,7 @@ mod tests {
             "svc-target",
             "yieldspace:svc/invoke",
             "call",
-            &[0x01, 0x02],
+            vec![0x01, 0x02],
         )
         .expect("local invoke should succeed");
         assert_eq!(actual, vec![0xAA, 0xBB]);

--- a/crates/imagod-runtime-wasmtime/src/runtime_entry.rs
+++ b/crates/imagod-runtime-wasmtime/src/runtime_entry.rs
@@ -418,7 +418,7 @@ impl WasmRuntime {
         bindings: &[ServiceBinding],
         interface_id: &str,
         function: &str,
-        payload_cbor: &[u8],
+        payload_cbor: Vec<u8>,
     ) -> Result<Vec<u8>, ImagodError> {
         let component = Component::from_file(&self.engine, component_path).map_err(|e| {
             map_runtime_error(format!(
@@ -479,7 +479,7 @@ impl WasmRuntime {
 
         if let Ok(typed_func) = func.typed::<(Vec<u8>,), (Vec<u8>,)>(&store) {
             let (result_bytes,) = typed_func
-                .call_async(&mut store, (payload_cbor.to_vec(),))
+                .call_async(&mut store, (payload_cbor,))
                 .await
                 .map_err(|e| map_runtime_error(format!("rpc invoke trap: {e}")))?;
             return Ok(result_bytes);
@@ -487,7 +487,7 @@ impl WasmRuntime {
 
         if let Ok(typed_func) = func.typed::<(Vec<u8>,), (Result<Vec<u8>, String>,)>(&store) {
             let (result_value,) = typed_func
-                .call_async(&mut store, (payload_cbor.to_vec(),))
+                .call_async(&mut store, (payload_cbor,))
                 .await
                 .map_err(|e| map_runtime_error(format!("rpc invoke trap: {e}")))?;
             return match result_value {
@@ -501,7 +501,7 @@ impl WasmRuntime {
         let func_ty = func.ty(&store);
         let param_types = func_ty.params().map(|(_, ty)| ty).collect::<Vec<_>>();
         let result_types = func_ty.results().collect::<Vec<_>>();
-        let params = decode_payload_values(payload_cbor, &param_types).map_err(|err| {
+        let params = decode_payload_values(&payload_cbor, &param_types).map_err(|err| {
             map_runtime_error(format!(
                 "failed to decode rpc payload for '{}.{}': {}",
                 interface_id, function, err.message
@@ -572,7 +572,7 @@ impl WasmRuntime {
             &bindings,
             &interface_id,
             &function,
-            &payload_cbor,
+            payload_cbor,
         )
         .await
     }
@@ -867,8 +867,10 @@ mod tests {
     use std::{
         collections::BTreeMap,
         fs,
+        hint::black_box,
         net::SocketAddr,
         path::{Path, PathBuf},
+        time::Instant,
     };
     use tempfile::{Builder as TempDirBuilder, TempDir};
     use wit_component::{ComponentEncoder, StringEncoding, dummy_module};
@@ -900,6 +902,21 @@ mod tests {
         }
     }
 
+    fn p95_micros(samples: &mut [u128]) -> u128 {
+        assert!(!samples.is_empty(), "samples must not be empty");
+        samples.sort_unstable();
+        let index = (samples.len() - 1) * 95 / 100;
+        samples[index]
+    }
+
+    fn legacy_prepare_payload(payload: &[u8]) -> Vec<u8> {
+        payload.to_vec()
+    }
+
+    fn optimized_prepare_payload(payload: Vec<u8>) -> Vec<u8> {
+        payload
+    }
+
     #[test]
     fn http_request_queue_capacity_uses_configured_queue_capacity_only() {
         assert_eq!(http_request_queue_capacity(1, 4), 4);
@@ -907,6 +924,39 @@ mod tests {
         assert_eq!(
             http_request_queue_capacity(0, 0),
             HTTP_REQUEST_QUEUE_CAPACITY
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn rpc_payload_move_perf_compare() {
+        const PAYLOAD_BYTES: usize = 1024 * 1024;
+        const ITERATIONS: usize = 64;
+        let payloads = (0..ITERATIONS)
+            .map(|_| vec![0xCD; PAYLOAD_BYTES])
+            .collect::<Vec<_>>();
+
+        let mut legacy_samples = Vec::with_capacity(ITERATIONS);
+        for payload in &payloads {
+            let started = Instant::now();
+            let prepared = legacy_prepare_payload(payload);
+            black_box(prepared);
+            legacy_samples.push(started.elapsed().as_micros());
+        }
+
+        let mut optimized_samples = Vec::with_capacity(ITERATIONS);
+        for payload in payloads {
+            let started = Instant::now();
+            let prepared = optimized_prepare_payload(payload);
+            black_box(prepared);
+            optimized_samples.push(started.elapsed().as_micros());
+        }
+
+        let legacy_p95 = p95_micros(&mut legacy_samples);
+        let optimized_p95 = p95_micros(&mut optimized_samples);
+        eprintln!(
+            "rpc_payload_move_perf_compare payload_bytes={} iterations={} optimized_p95_us={} legacy_p95_us={}",
+            PAYLOAD_BYTES, ITERATIONS, optimized_p95, legacy_p95
         );
     }
 

--- a/crates/imagod-server/src/protocol_handler/router.rs
+++ b/crates/imagod-server/src/protocol_handler/router.rs
@@ -219,14 +219,15 @@ impl ProtocolHandler {
             .validate()
             .map_err(|e| bad_request("rpc.invoke", e.to_string()))?;
 
+        let RpcInvokeRequest {
+            interface_id,
+            function,
+            args_cbor,
+            target_service,
+        } = payload;
         let response = match self
             .orchestrator
-            .invoke(
-                &payload.target_service.name,
-                &payload.interface_id,
-                &payload.function,
-                &payload.args_cbor,
-            )
+            .invoke(&target_service.name, &interface_id, &function, args_cbor)
             .await
         {
             Ok(result_cbor) => RpcInvokeResponse::from_result(result_cbor),

--- a/plugins/imago-node/src/lib.rs
+++ b/plugins/imago-node/src/lib.rs
@@ -122,7 +122,7 @@ impl imago_node_plugin_bindings::imago::node::rpc::HostConnection for WasiState 
             &target_service,
             &interface_id,
             &function,
-            &args_cbor,
+            args_cbor,
         )
     }
 
@@ -364,7 +364,7 @@ mod tests {
             "svc-target",
             "yieldspace:svc/invoke",
             "call",
-            &[0x01, 0x02],
+            vec![0x01, 0x02],
         )
         .expect("local invoke should succeed");
         assert_eq!(actual, vec![0xAA, 0xBB]);


### PR DESCRIPTION
## Motivation
- IPC receive path で同一 CBOR frame を二重 decode しており、CPU コストが余分に発生していました。
- invoke 経路で `payload_cbor.to_vec()` が複数箇所にあり、4-8MiB クラス payload で一時メモリとレイテンシ悪化要因になっていました。
- issue #229 の受け入れ条件（重複 decode 排除と payload copy 削減）を満たす必要がありました。

## Summary
- `DbusP2pTransport::read_message` を single-decode 化し、decode 済み値に対して validation を実施するよう変更しました（wire 契約は維持）。
- RPC invoke 経路の内部契約を `&[u8]` 借用から `Vec<u8>` 所有権移動に変更し、以下の `to_vec()` を除去しました。
- 変更対象: orchestrator / service_supervisor / manager_control / remote_rpc / rpc_bridge / plugin_resolver / runtime_entry / server router / imago-node plugin。
- `#[ignore]` の比較ベンチを2件追加しました。
- `read_message_decode_perf_compare`（legacy double-decode vs optimized single-decode）
- `rpc_payload_move_perf_compare`（legacy clone vs optimized move）

## Validation
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo test -p imagod-ipc -- --ignored --nocapture` ✅
- `read_message_decode_perf_compare payload_bytes=4194304 iterations=64 optimized_p95_us=850783 legacy_p95_us=1565176`
- `cargo test -p imagod-runtime-wasmtime -- --ignored --nocapture` ⚠️
- 既存の `http_response_perf_compare` が RSS assert で失敗（今回追加分ではない）
- `cargo test -p imagod-runtime-wasmtime rpc_payload_move_perf_compare -- --ignored --nocapture` ✅
- `rpc_payload_move_perf_compare payload_bytes=1048576 iterations=64 optimized_p95_us=0 legacy_p95_us=71`
