### PR TITLE
Fix parent spinner leakage before delegated log streaming

### DIFF
--- a/crates/imago-cli/src/commands/compose/mod.rs
+++ b/crates/imago-cli/src/commands/compose/mod.rs
@@ -104,6 +104,10 @@ fn compose_ls_failure_error(ps_result: &CommandResult) -> ComposeCommandError {
     }
 }
 
+fn should_clear_stack_spinner_before_logs(_follow: bool) -> bool {
+    true
+}
+
 pub async fn run(args: ComposeSubcommandArgs) -> CommandResult {
     run_with_project_root(args, Path::new(".")).await
 }
@@ -512,6 +516,10 @@ async fn run_compose_logs(
         && name.trim().is_empty()
     {
         return Err(anyhow!("stack logs --name must not be empty"));
+    }
+
+    if should_clear_stack_spinner_before_logs(args.follow) {
+        ui::command_clear("stack");
     }
 
     let logs_result = logs::run_with_project_root_and_target_override(
@@ -975,6 +983,16 @@ type = "cli"
         );
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn clear_stack_spinner_before_logs_when_follow_enabled() {
+        assert!(should_clear_stack_spinner_before_logs(true));
+    }
+
+    #[test]
+    fn clear_stack_spinner_before_logs_when_follow_disabled() {
+        assert!(should_clear_stack_spinner_before_logs(false));
     }
 
     #[tokio::test]

--- a/crates/imago-cli/src/commands/deploy/mod.rs
+++ b/crates/imago-cli/src/commands/deploy/mod.rs
@@ -216,6 +216,10 @@ fn print_build_failure_logs(err: &anyhow::Error) {
     println!("{}", build_failure_footer_line());
 }
 
+fn should_clear_deploy_spinner_before_follow(detach: bool) -> bool {
+    !detach
+}
+
 fn format_deploy_structured_error(error: &StructuredError) -> String {
     let mut formatted = format!("{} ({:?}) at {}", error.message, error.code, error.stage);
     append_wasm_log_section(&mut formatted, error, DETAIL_WASM_STDOUT, "wasm stdout");
@@ -626,7 +630,8 @@ async fn run_async_with_target_override(
         terminal.ok_or_else(|| anyhow!("command.event terminal event was not received"))?;
     match terminal.event_type {
         CommandEventType::Succeeded => {
-            if !detach {
+            if should_clear_deploy_spinner_before_follow(detach) {
+                ui::command_clear("service.deploy");
                 follow_logs_after_deploy(project_root, &target_config_for_logs, &manifest.name)
                     .await;
             }
@@ -3012,6 +3017,16 @@ mod tests {
             deploy_phase_detail(DEPLOY_PHASE_COMMAND, "remote progress"),
             "phase 8/8 remote progress"
         );
+    }
+
+    #[test]
+    fn clear_deploy_spinner_before_follow_when_not_detached() {
+        assert!(should_clear_deploy_spinner_before_follow(false));
+    }
+
+    #[test]
+    fn keep_deploy_spinner_when_detached() {
+        assert!(!should_clear_deploy_spinner_before_follow(true));
     }
 
     #[test]

--- a/crates/imago-cli/src/commands/run.rs
+++ b/crates/imago-cli/src/commands/run.rs
@@ -20,6 +20,10 @@ use crate::{
 
 const AUTO_FOLLOW_TAIL_LINES: u32 = 200;
 
+fn should_clear_start_spinner_before_follow(detach: bool) -> bool {
+    !detach
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RunSummary {
     service_name: String,
@@ -120,7 +124,8 @@ async fn run_async(args: RunArgs, project_root: &Path) -> anyhow::Result<RunSumm
     )
     .await?;
     handle_terminal_event("service.start", responses)?;
-    if !detach {
+    if should_clear_start_spinner_before_follow(detach) {
+        ui::command_clear("service.start");
         follow_logs_after_run(project_root, &target_config, &service_name).await;
     }
     Ok(RunSummary {
@@ -159,6 +164,7 @@ async fn follow_logs_after_run(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::commands::command_common::resolve_service_name;
     use std::{
         fs,
@@ -248,5 +254,15 @@ remote = "127.0.0.1:4443"
         assert_eq!(name, "svc-default");
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn clear_start_spinner_before_follow_when_not_detached() {
+        assert!(should_clear_start_spinner_before_follow(false));
+    }
+
+    #[test]
+    fn keep_start_spinner_when_detached() {
+        assert!(!should_clear_start_spinner_before_follow(true));
     }
 }

--- a/docs/cli-output-contract.md
+++ b/docs/cli-output-contract.md
@@ -43,6 +43,15 @@ This document defines the user-facing output contract for `imago` CLI commands.
   - what was deployed (`service`, `deploy_id`)
   - where it was deployed (`target`, `authority`, `resolved`)
   - when deployment completed (`deployed_at`)
+- When `service.deploy` delegates to `service logs --follow`, `service.deploy` progress spinners must be cleared before streamed log lines begin.
+
+### service.start
+
+- When `service.start` delegates to `service logs --follow`, `service.start` progress spinners must be cleared before streamed log lines begin.
+
+### stack logs
+
+- `stack logs` must clear the `stack` progress spinner before delegating to `service.logs` so streamed log lines are not interleaved with parent spinner redraws.
 
 ### service.logs
 


### PR DESCRIPTION
## Motivation
- `imago service deploy --follow` 実行時に `service.deploy` のスピナーがログ出力中も再描画され続け、最新ログ行を視認しづらい問題がありました（issue #245）。
- `service.start --follow` と `stack logs` でも親コマンドのスピナーとログストリームが干渉しうるため、ストリーム表示系で挙動を統一して表示ノイズを解消する必要がありました。

## Summary
- `service.deploy` 成功後に `--follow` へ委譲する前、`ui::command_clear("service.deploy")` を実行するよう更新。
- `service.start` 成功後に `--follow` へ委譲する前、`ui::command_clear("service.start")` を実行するよう更新。
- `stack logs` は `--follow` の有無に関わらず `service.logs` へ委譲する前に `ui::command_clear("stack")` を実行するよう更新。
- 各コマンドでスピナークリア方針を固定する分岐テストを追加。
- CLI 出力契約に `service.deploy` / `service.start` / `stack logs` の親スピナークリア要件を追記（`docs/cli-output-contract.md`）。

## Validation
- `cargo fmt --all`
  - 成功
- `cargo clippy --workspace --all-targets -- -D warnings`
  - 成功（warning/error なし）
- `cargo test --workspace`
  - 成功（passed: 941, failed: 0, ignored: 3）
- `cargo fmt --all`（final pass）
  - 成功
