### PR TITLE
Update dependabot-automerge runner to ubuntu-latest

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -19,7 +19,7 @@ jobs:
   automerge:
     name: enable auto-merge for dependabot patch updates
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.state == 'open' }}
-    runs-on: imago-default-runner-set
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- Dependabot 自動マージ workflow が self-hosted runner セットに依存しており、実行環境が限定されていました。
- GitHub-hosted runner (`ubuntu-latest`) に切り替えて、Dependabot PR での auto-merge 有効化ジョブを安定して実行できるようにします。

## Summary
- `.github/workflows/dependabot-automerge.yml` の `automerge` job で `runs-on` を `imago-default-runner-set` から `ubuntu-latest` に変更しました。
- プロトコル契約や Rust 実装への変更はありません。

## Validation
- Rust-impact gate: changed file が workflow YAML のみ（`.github/workflows/dependabot-automerge.yml`）のため、Rust preflight (`cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace`) はスキップしました。
- `git diff -- .github/workflows/dependabot-automerge.yml`
  - `runs-on` の1行のみ差分であることを確認。
- `gh auth status`
  - `github.com` で `sizumita` アカウントが active であることを確認。
