### PR TITLE
Enable changelog_update and release labels for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,7 +6,8 @@ git_only = true
 git_tag_enable = false
 git_release_enable = false
 git_release_type = "pre"
-changelog_update = false
+changelog_update = true
+pr_labels = ["release"]
 
 [[package]]
 name = "imago-cli"


### PR DESCRIPTION
## Motivation
- release-plz が対象変更を取り込んだ release PR を安定して作成できるように、workspace 設定を明示する必要がありました。
- `changelog_update` が無効なままだと changelog 更新フローが走らず、期待する PR 生成条件を満たせません。

## Summary
- `release-plz.toml` の `[workspace]` で `changelog_update = true` に変更しました。
- 同じく `[workspace]` に `pr_labels = ["release"]` を追加し、release PR に `release` ラベルが付与されるようにしました。

## Validation
- `git show --name-only --pretty='format:' HEAD`
  - 出力: `release-plz.toml`
- 変更は Rust ソース/依存関係に影響しない設定ファイルのみのため、`cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` はスキップしました。
