### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/imago-cli/CHANGELOG.md
+++ b/crates/imago-cli/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imago-v0.1.0) - 2026-03-02
+
+### Other
+
+- Add release-based imagod installer and checksum assets ([#266](https://github.com/yieldspace/imago/pull/266))
+- Strengthen imago.lock v1 validation and component source resolution ([#264](https://github.com/yieldspace/imago/pull/264))
+- Rework deps sync resolution and dependency source contracts ([#249](https://github.com/yieldspace/imago/pull/249))
+- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
+- Improve project init template flow and add componentize-py example ([#246](https://github.com/yieldspace/imago/pull/246))
+- Fix spinner leakage before delegated log streaming ([#247](https://github.com/yieldspace/imago/pull/247))
+- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
+- Use resources.gpio.digital_pins for experimental GPIO plugin ([#237](https://github.com/yieldspace/imago/pull/237))
+- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
+- Remove --json output mode from imago CLI ([#221](https://github.com/yieldspace/imago/pull/221))
+- Bump wit-component from 0.244.0 to 0.245.1 ([#192](https://github.com/yieldspace/imago/pull/192))
+- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
+- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
+- Add auto log follow for run and deploy ([#210](https://github.com/yieldspace/imago/pull/210))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
+- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
+- Update init template validation to parse TOML config ([#198](https://github.com/yieldspace/imago/pull/198))
+- Update certs generate to client-only output ([#184](https://github.com/yieldspace/imago/pull/184))
+- Add imago init command with template auto-detection ([#183](https://github.com/yieldspace/imago/pull/183))
+- Add wildcard support for capabilities.deps ([#181](https://github.com/yieldspace/imago/pull/181))
+- Support deep OCI WIT source paths and dependency package checks ([#179](https://github.com/yieldspace/imago/pull/179))
+- Fix transitive WARG registry resolution for wasi packages ([#178](https://github.com/yieldspace/imago/pull/178))
+- Merge dotenv into wasi env and add e2e coverage ([#176](https://github.com/yieldspace/imago/pull/176))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
+- Add help docstrings for imago-cli commands ([#166](https://github.com/yieldspace/imago/pull/166))
+- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Return logs as JSON lines ([#156](https://github.com/yieldspace/imago/pull/156))
+- Unify logs filter identifier to name ([#152](https://github.com/yieldspace/imago/pull/152))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Add imago run/stop commands and restart policy handling ([#150](https://github.com/yieldspace/imago/pull/150))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
+- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
+- Implement #71 idempotency key hashing and upload resume retry ([#136](https://github.com/yieldspace/imago/pull/136))
+- Handle invalid certificate failures as E_UNAUTHORIZED ([#135](https://github.com/yieldspace/imago/pull/135))
+- Add imago build pipeline and manifest-relative main packaging ([#134](https://github.com/yieldspace/imago/pull/134))
+- Implement imagod deploy core (QUIC/WebTransport + async Wasmtime) and Phase 1 sub-issues ([#133](https://github.com/yieldspace/imago/pull/133))
+- Add imago-cli deploy基盤crate ([#131](https://github.com/yieldspace/imago/pull/131))

--- a/crates/imagod-common/CHANGELOG.md
+++ b/crates/imagod-common/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-common-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod-config/CHANGELOG.md
+++ b/crates/imagod-config/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-config-v0.1.0) - 2026-03-02
+
+### Other
+
+- Add release-based imagod installer and checksum assets ([#266](https://github.com/yieldspace/imago/pull/266))
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
+- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
+- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
+- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
+- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
+- imagod autocreate: generate server key and allow empty client key allowlist ([#172](https://github.com/yieldspace/imago/pull/172))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Update imagod storage_root defaults by OS and build-time override ([#149](https://github.com/yieldspace/imago/pull/149))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod-control/CHANGELOG.md
+++ b/crates/imagod-control/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-control-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize logs path and heartbeat lookup for #230/#231/#232 ([#265](https://github.com/yieldspace/imago/pull/265))
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
+- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
+- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
+- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
+- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
+- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
+- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
+- Stop mirroring wasm stdout/stderr to imagod console ([#208](https://github.com/yieldspace/imago/pull/208))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
+- Update deploy failure observability and stale start recovery ([#201](https://github.com/yieldspace/imago/pull/201))
+- Fix deploy rollback recovery when service is busy ([#182](https://github.com/yieldspace/imago/pull/182))
+- Merge dotenv into wasi env and add e2e coverage ([#176](https://github.com/yieldspace/imago/pull/176))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
+- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Add imago run/stop commands and restart policy handling ([#150](https://github.com/yieldspace/imago/pull/150))
+- imagod起動時にactive_releaseサービスを自動復元する ([#148](https://github.com/yieldspace/imago/pull/148))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
+- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod-ipc/CHANGELOG.md
+++ b/crates/imagod-ipc/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-ipc-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
+- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod-runtime-bootstrap/CHANGELOG.md
+++ b/crates/imagod-runtime-bootstrap/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-bootstrap-v0.1.0) - 2026-03-02
+
+### Other
+
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))

--- a/crates/imagod-runtime-control/CHANGELOG.md
+++ b/crates/imagod-runtime-control/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-control-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))

--- a/crates/imagod-runtime-ingress/CHANGELOG.md
+++ b/crates/imagod-runtime-ingress/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-ingress-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
+- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))

--- a/crates/imagod-runtime-internal/CHANGELOG.md
+++ b/crates/imagod-runtime-internal/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-internal-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))

--- a/crates/imagod-runtime-wasmtime/CHANGELOG.md
+++ b/crates/imagod-runtime-wasmtime/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-wasmtime-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
+- Use resources.gpio.digital_pins for experimental GPIO plugin ([#237](https://github.com/yieldspace/imago/pull/237))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- Update wasmtime to 42.0.0 for RustSec fix ([#207](https://github.com/yieldspace/imago/pull/207))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
+- Enable WASI HTTP linker for all component instantiate paths ([#197](https://github.com/yieldspace/imago/pull/197))
+- Fix native plugin linker duplication and add NanoKVM e2e coverage ([#185](https://github.com/yieldspace/imago/pull/185))
+- Add wildcard support for capabilities.deps ([#181](https://github.com/yieldspace/imago/pull/181))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))

--- a/crates/imagod-runtime/CHANGELOG.md
+++ b/crates/imagod-runtime/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
+- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
+- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
+- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
+- Update imagod storage_root defaults by OS and build-time override ([#149](https://github.com/yieldspace/imago/pull/149))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod-server/CHANGELOG.md
+++ b/crates/imagod-server/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-server-v0.1.0) - 2026-03-02
+
+### Other
+
+- Optimize logs path and heartbeat lookup for #230/#231/#232 ([#265](https://github.com/yieldspace/imago/pull/265))
+- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
+- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
+- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
+- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
+- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
+- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
+- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
+- Update deploy failure observability and stale start recovery ([#201](https://github.com/yieldspace/imago/pull/201))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
+- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Unify logs filter identifier to name ([#152](https://github.com/yieldspace/imago/pull/152))
+- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))

--- a/crates/imagod/CHANGELOG.md
+++ b/crates/imagod/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-v0.1.0) - 2026-03-02
+
+### Other
+
+- Update imagod version/help protocol display ([#269](https://github.com/yieldspace/imago/pull/269))
+- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
+- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
+- Add imago:usb rusb plugin with wasi-usb parity APIs ([#242](https://github.com/yieldspace/imago/pull/242))
+- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
+- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
+- Add async experimental i2c native plugin ([#225](https://github.com/yieldspace/imago/pull/225))
+- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
+- Add imagod library API and NanoKVM custom daemon/plugin ([#175](https://github.com/yieldspace/imago/pull/175))
+- imagod autocreate: generate server key and allow empty client key allowlist ([#172](https://github.com/yieldspace/imago/pull/172))
+- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
+- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
+- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
+- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
+- imagod起動時にactive_releaseサービスを自動復元する ([#148](https://github.com/yieldspace/imago/pull/148))
+- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
+- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
+- Implement imagod deploy core (QUIC/WebTransport + async Wasmtime) and Phase 1 sub-issues ([#133](https://github.com/yieldspace/imago/pull/133))


### PR DESCRIPTION



## 🤖 New release

* `imago-cli`: 0.1.0
* `imagod-common`: 0.1.0
* `imagod-config`: 0.1.0
* `imagod-ipc`: 0.1.0
* `imagod-control`: 0.1.0
* `imagod-runtime-bootstrap`: 0.1.0
* `imagod-runtime-internal`: 0.1.0
* `imagod-runtime-control`: 0.1.0
* `imagod-runtime-ingress`: 0.1.0
* `imagod-runtime-wasmtime`: 0.1.0
* `imagod-runtime`: 0.1.0
* `imagod-server`: 0.1.0
* `imagod`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `imago-cli`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imago-v0.1.0) - 2026-03-02

### Other

- Add release-based imagod installer and checksum assets ([#266](https://github.com/yieldspace/imago/pull/266))
- Strengthen imago.lock v1 validation and component source resolution ([#264](https://github.com/yieldspace/imago/pull/264))
- Rework deps sync resolution and dependency source contracts ([#249](https://github.com/yieldspace/imago/pull/249))
- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
- Improve project init template flow and add componentize-py example ([#246](https://github.com/yieldspace/imago/pull/246))
- Fix spinner leakage before delegated log streaming ([#247](https://github.com/yieldspace/imago/pull/247))
- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
- Use resources.gpio.digital_pins for experimental GPIO plugin ([#237](https://github.com/yieldspace/imago/pull/237))
- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
- Remove --json output mode from imago CLI ([#221](https://github.com/yieldspace/imago/pull/221))
- Bump wit-component from 0.244.0 to 0.245.1 ([#192](https://github.com/yieldspace/imago/pull/192))
- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
- Add auto log follow for run and deploy ([#210](https://github.com/yieldspace/imago/pull/210))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
- Update init template validation to parse TOML config ([#198](https://github.com/yieldspace/imago/pull/198))
- Update certs generate to client-only output ([#184](https://github.com/yieldspace/imago/pull/184))
- Add imago init command with template auto-detection ([#183](https://github.com/yieldspace/imago/pull/183))
- Add wildcard support for capabilities.deps ([#181](https://github.com/yieldspace/imago/pull/181))
- Support deep OCI WIT source paths and dependency package checks ([#179](https://github.com/yieldspace/imago/pull/179))
- Fix transitive WARG registry resolution for wasi packages ([#178](https://github.com/yieldspace/imago/pull/178))
- Merge dotenv into wasi env and add e2e coverage ([#176](https://github.com/yieldspace/imago/pull/176))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
- Add help docstrings for imago-cli commands ([#166](https://github.com/yieldspace/imago/pull/166))
- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Return logs as JSON lines ([#156](https://github.com/yieldspace/imago/pull/156))
- Unify logs filter identifier to name ([#152](https://github.com/yieldspace/imago/pull/152))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Add imago run/stop commands and restart policy handling ([#150](https://github.com/yieldspace/imago/pull/150))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
- Implement #71 idempotency key hashing and upload resume retry ([#136](https://github.com/yieldspace/imago/pull/136))
- Handle invalid certificate failures as E_UNAUTHORIZED ([#135](https://github.com/yieldspace/imago/pull/135))
- Add imago build pipeline and manifest-relative main packaging ([#134](https://github.com/yieldspace/imago/pull/134))
- Implement imagod deploy core (QUIC/WebTransport + async Wasmtime) and Phase 1 sub-issues ([#133](https://github.com/yieldspace/imago/pull/133))
- Add imago-cli deploy基盤crate ([#131](https://github.com/yieldspace/imago/pull/131))
</blockquote>

## `imagod-common`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-common-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod-config`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-config-v0.1.0) - 2026-03-02

### Other

- Add release-based imagod installer and checksum assets ([#266](https://github.com/yieldspace/imago/pull/266))
- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
- imagod autocreate: generate server key and allow empty client key allowlist ([#172](https://github.com/yieldspace/imago/pull/172))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Update imagod storage_root defaults by OS and build-time override ([#149](https://github.com/yieldspace/imago/pull/149))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod-ipc`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-ipc-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod-control`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-control-v0.1.0) - 2026-03-02

### Other

- Optimize logs path and heartbeat lookup for #230/#231/#232 ([#265](https://github.com/yieldspace/imago/pull/265))
- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
- Stop mirroring wasm stdout/stderr to imagod console ([#208](https://github.com/yieldspace/imago/pull/208))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
- Update deploy failure observability and stale start recovery ([#201](https://github.com/yieldspace/imago/pull/201))
- Fix deploy rollback recovery when service is busy ([#182](https://github.com/yieldspace/imago/pull/182))
- Merge dotenv into wasi env and add e2e coverage ([#176](https://github.com/yieldspace/imago/pull/176))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Add imago run/stop commands and restart policy handling ([#150](https://github.com/yieldspace/imago/pull/150))
- imagod起動時にactive_releaseサービスを自動復元する ([#148](https://github.com/yieldspace/imago/pull/148))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod-runtime-bootstrap`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-bootstrap-v0.1.0) - 2026-03-02

### Other

- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
</blockquote>

## `imagod-runtime-internal`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-internal-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
</blockquote>

## `imagod-runtime-control`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-control-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
</blockquote>

## `imagod-runtime-ingress`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-ingress-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Rename CLI commands to v2 hierarchy ([#239](https://github.com/yieldspace/imago/pull/239))
- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
</blockquote>

## `imagod-runtime-wasmtime`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-wasmtime-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
- Use resources.gpio.digital_pins for experimental GPIO plugin ([#237](https://github.com/yieldspace/imago/pull/237))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Reduce HTTP response body copy amplification in runtime ([#233](https://github.com/yieldspace/imago/pull/233))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- Update wasmtime to 42.0.0 for RustSec fix ([#207](https://github.com/yieldspace/imago/pull/207))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
- Enable WASI HTTP linker for all component instantiate paths ([#197](https://github.com/yieldspace/imago/pull/197))
- Fix native plugin linker duplication and add NanoKVM e2e coverage ([#185](https://github.com/yieldspace/imago/pull/185))
- Add wildcard support for capabilities.deps ([#181](https://github.com/yieldspace/imago/pull/181))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
</blockquote>

## `imagod-runtime`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-runtime-v0.1.0) - 2026-03-02

### Other

- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Add resources section foundation for host policy ([#235](https://github.com/yieldspace/imago/pull/235))
- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
- Add HTTP outbound e2e tests and CIDR IPC round-trip fix ([#206](https://github.com/yieldspace/imago/pull/206))
- Add deploy failure wasm log diagnostics and e2e coverage ([#205](https://github.com/yieldspace/imago/pull/205))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- Add type=socket runtime support and local UDP echo example ([#151](https://github.com/yieldspace/imago/pull/151))
- Update imagod storage_root defaults by OS and build-time override ([#149](https://github.com/yieldspace/imago/pull/149))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod-server`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-server-v0.1.0) - 2026-03-02

### Other

- Optimize logs path and heartbeat lookup for #230/#231/#232 ([#265](https://github.com/yieldspace/imago/pull/265))
- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
- Optimize IPC decode and RPC payload ownership in invoke path ([#244](https://github.com/yieldspace/imago/pull/244))
- Add scenario-driven imagod security test redesign ([#241](https://github.com/yieldspace/imago/pull/241))
- Update logs output format and add --with-timestamp support ([#226](https://github.com/yieldspace/imago/pull/226))
- Replace compatibility_date with protocol version negotiation ([#218](https://github.com/yieldspace/imago/pull/218))
- remove docs/spec and adopt code-first source of truth ([#217](https://github.com/yieldspace/imago/pull/217))
- Harden deploy stream handling for post-accept command.start failures ([#202](https://github.com/yieldspace/imago/pull/202))
- Update deploy failure observability and stale start recovery ([#201](https://github.com/yieldspace/imago/pull/201))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Add imago ps and compose ps listing commands ([#168](https://github.com/yieldspace/imago/pull/168))
- Allow logs of retained services while imagod is running ([#164](https://github.com/yieldspace/imago/pull/164))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Unify logs filter identifier to name ([#152](https://github.com/yieldspace/imago/pull/152))
- Implement logs over QUIC DATAGRAM and fix datagram oversize ([#145](https://github.com/yieldspace/imago/pull/145))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
</blockquote>

## `imagod`

<blockquote>

## [0.1.0](https://github.com/yieldspace/imago/releases/tag/imagod-v0.1.0) - 2026-03-02

### Other

- Update imagod version/help protocol display ([#269](https://github.com/yieldspace/imago/pull/269))
- Optimize imagod runner memory and component loading ([#254](https://github.com/yieldspace/imago/pull/254))
- Reduce manager memory overhead in deploy and retained logs ([#248](https://github.com/yieldspace/imago/pull/248))
- Add imago:usb rusb plugin with wasi-usb parity APIs ([#242](https://github.com/yieldspace/imago/pull/242))
- Add imago experimental GPIO native plugin and local example ([#236](https://github.com/yieldspace/imago/pull/236))
- Bound HTTP request queue memory under burst traffic ([#234](https://github.com/yieldspace/imago/pull/234))
- Add async experimental i2c native plugin ([#225](https://github.com/yieldspace/imago/pull/225))
- Replace nanokvm e2e linker test with runtime tests ([#199](https://github.com/yieldspace/imago/pull/199))
- Add imagod library API and NanoKVM custom daemon/plugin ([#175](https://github.com/yieldspace/imago/pull/175))
- imagod autocreate: generate server key and allow empty client key allowlist ([#172](https://github.com/yieldspace/imago/pull/172))
- Apply workspace-wide cargo-deny guardrails ([#169](https://github.com/yieldspace/imago/pull/169))
- Imago Networkの実装 ([#162](https://github.com/yieldspace/imago/pull/162))
- Refactor workspace boundaries and harden Tokio runtime paths ([#159](https://github.com/yieldspace/imago/pull/159))
- Add WIT-native plugin flow and imago-lockfile v1 ([#157](https://github.com/yieldspace/imago/pull/157))
- imagod起動時にactive_releaseサービスを自動復元する ([#148](https://github.com/yieldspace/imago/pull/148))
- Split runtime backend into feature-gated crates ([#147](https://github.com/yieldspace/imago/pull/147))
- migrate to multi-process runtime and workspace-managed deps ([#138](https://github.com/yieldspace/imago/pull/138))
- Implement imagod deploy core (QUIC/WebTransport + async Wasmtime) and Phase 1 sub-issues ([#133](https://github.com/yieldspace/imago/pull/133))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).