### PR TITLE
docs: Add release-plz PR prefix and BREAKING CHANGE rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Treat these three template sections as the only authoritative PR-body contract.
 Include required details inside those sections: what changed and why, linked issue/PR context, validation commands, and spec/compatibility impact notes.
 
 ### PR Title Prefix and Breaking Footer (release-plz)
-- Use Conventional Commit style for PR titles: `<prefix><summary>`.
+- Use Conventional Commit style for PR titles: `<prefix> <summary>`.
 - Start every PR title with exactly one allowed prefix: `fix:`, `feat:`, `feat!:`, `ci:`, or `docs:`.
 - Prefix-to-impact mapping for release-plz:
   - `feat!:` => Major


### PR DESCRIPTION
## Motivation
- We started using `release-plz`, so PR title semantics need to be explicit and consistent for impact classification.
- Without a clear prefix and breaking-change footer policy, release impact signaling can become ambiguous.

## Summary
- Updated `AGENTS.md` under `Commit & PR Rules` with a new section: `PR Title Prefix and Breaking Footer (release-plz)`.
- Documented allowed PR title prefixes: `fix:`, `feat:`, `feat!:`, `ci:`, `docs:`.
- Added impact mapping and precedence, including `BREAKING CHANGE:` footer handling and squash-merge preservation requirements.

## Validation
- `git diff --name-only HEAD~1..HEAD`
  - Result: `AGENTS.md` only (non-Rust-impacting change).
- Rust preflight checks were skipped by rule because no Rust-impacting files were changed (`*.rs`, `Cargo.toml`, `Cargo.lock`, `build.rs`, `.cargo/**`, `rust-toolchain*`, `*.wit`, `*.proto` none changed).
- `rg -n "feat!|feat:|fix:|ci:|docs:|BREAKING CHANGE|release-plz" AGENTS.md`
  - Result: Added rules were detected in the new section.
