### PR TITLE
fix: set GH_REPO for release asset upload job

### DIFF
--- a/.github/workflows/imago-build.yml
+++ b/.github/workflows/imago-build.yml
@@ -166,4 +166,5 @@ jobs:
       - name: Upload artifacts to existing GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber


### PR DESCRIPTION
## Motivation
- GitHub Actions の `Upload release assets` ジョブで `gh release upload` 実行時に `.git` が無い環境となり、`fatal: not a git repository` で失敗していたため。
- release アセットの最終アップロードが止まると、リリース成果物公開フローが完了しないため。

## Summary
- `.github/workflows/imago-build.yml` の `Upload artifacts to existing GitHub Release` ステップに `GH_REPO: ${{ github.repository }}` を追加。
- `gh` がローカルの git 作業ツリーに依存せず、対象リポジトリを明示して release upload できるように修正。
- 本変更は workflow YAML のみで、Rust 実装/契約/ドキュメントへの影響はなし。

## Validation
- `gh run view 22602369737 --repo yieldspace/imago --job 65489894740 --log-failed`
  - `failed to run git: fatal: not a git repository` を確認して原因を特定。
- `tmpdir=$(mktemp -d) && cd "$tmpdir" && GH_REPO=yieldspace/imago gh release view imagod-v0.1.0 --json tagName`
  - `.git` がないディレクトリでも `{"tagName":"imagod-v0.1.0"}` を取得できることを確認。
- Rust impact gate
  - 変更ファイルは `.github/workflows/imago-build.yml` のみのため、`cargo fmt --all` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` は non-Rust-impacting と判断してスキップ。
