### PR TITLE
ci: exempt pr body lint for release-labeled PRs

### DIFF
--- a/.github/workflows/ci-pr-body-checks.yml
+++ b/.github/workflows/ci-pr-body-checks.yml
@@ -7,6 +7,8 @@ on:
       - edited
       - reopened
       - synchronize
+      - labeled
+      - unlabeled
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation
- `release` ラベル付きPR（release-plz生成PRなど）は、通常の開発PRと同じPR本文要件を満たさないことがあり、`pr body lint` が不要に失敗する。
- Dependabot と同様に免除条件を明示し、`checks` ジョブで免除理由を判定可能にして誤失敗を防ぐ。

## Summary
- `.github/workflows/ci-pr-body-checks.yml` の `pr_body_lint` 条件を更新し、`release` ラベル付きPRでは lint をスキップするように変更。
- `allow_release` ジョブを追加し、releaseラベル免除を明示的に成功扱いで記録。
- `checks` ジョブの `needs` に `allow_release` を追加し、判定を「Dependabot / releaseラベル / 通常PR」の3分岐へ整理。
- 各分岐で `pr_body_lint` / `allow_dependabot` / `allow_release` の期待結果（success または skipped）を fail-closed で検証。

## Validation
- `git diff --name-only HEAD`
  - `.github/workflows/ci-pr-body-checks.yml` のみ変更（Rust非影響）
- Rust preflight (`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`)
  - 非Rust影響変更のためスキップ
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-pr-body-checks.yml"); puts "YAML_OK"'`
  - `YAML_OK`
- `actionlint .github/workflows/ci-pr-body-checks.yml`
  - `actionlint` 未導入のため未実行
