### PR TITLE
fix(ci): restore prup checkout credentials

### DIFF
--- a/.github/workflows/prup-release.yml
+++ b/.github/workflows/prup-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Run prup release action
         uses: ./.github/actions/prup-release
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Run prup release-pr action
         uses: ./.github/actions/prup-release-pr


### PR DESCRIPTION
## Motivation
- `prup release-pr` on `main` failed in [run 22731729315 / job 65922400388](https://github.com/yieldspace/imago/actions/runs/22731729315/job/65922400388) at `git push` with `fatal: could not read Username for 'https://github.com'`.
- The workflow disabled `actions/checkout` credential persistence, so the composite action had no authenticated Git remote when it tried to push the release branch.

## Summary
- Pass `secrets.RELEASE_PLZ_TOKEN` directly to both `actions/checkout@v6` steps in `prup-release.yml`.
- Keep the push logic inside the composite actions unchanged and rely on checkout-managed credentials, which is the documented path for authenticated git operations in GitHub Actions.

## Validation
- `bash -n .github/actions/prup-release-pr/run.sh`
- `bash -n .github/actions/prup-release/run.sh`
- `actionlint .github/workflows/prup-release.yml`
- Reviewed official docs for `actions/checkout@v6` `token` / credential persistence behavior and `gh auth setup-git` before selecting the workflow-side fix.
