### PR TITLE
ci(release): imago-cli 0.1.1 -> 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "imago-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/imago-cli/Cargo.toml
+++ b/crates/imago-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-cli"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 publish = true


### PR DESCRIPTION
## Release
- Line: `imago-cli`
- Top crate: `imago-cli`
- Bump: `minor`
- Version: `0.1.1` -> `0.2.0`
- Tag: `imago-v0.1.1` -> `imago-v0.2.0`

## Triggered By
- `imago-cli`
- `imago-project-config`

## Updated Crates
- `imago-cli`: `0.1.1` -> `0.2.0`

