### PR TITLE
fix: reduce imagod live log memory duplication

### DIFF
--- a/crates/imagod-control/src/lib.rs
+++ b/crates/imagod-control/src/lib.rs
@@ -23,6 +23,6 @@ pub use operation_state::{OperationManager, SpawnTransition};
 pub use orchestrator::{Orchestrator, RestoreActiveServicesSummary, RestoreFailure};
 /// Re-exports for service supervision primitives.
 pub use service_supervisor::{
-    RunningStatus, ServiceLaunch, ServiceLogEvent, ServiceLogStream, ServiceLogSubscription,
-    ServiceSupervisor,
+    RunningStatus, ServiceLaunch, ServiceLogEvent, ServiceLogSnapshot, ServiceLogStream,
+    ServiceLogSubscription, ServiceSupervisor,
 };

--- a/crates/imagod-control/src/orchestrator.rs
+++ b/crates/imagod-control/src/orchestrator.rs
@@ -459,9 +459,10 @@ impl Orchestrator {
         service_name: &str,
         tail_lines: u32,
         follow: bool,
+        with_timestamp: bool,
     ) -> Result<ServiceLogSubscription, ImagodError> {
         self.supervisor
-            .open_logs(service_name, tail_lines, follow)
+            .open_logs(service_name, tail_lines, follow, with_timestamp)
             .await
     }
 

--- a/crates/imagod-control/src/service_supervisor.rs
+++ b/crates/imagod-control/src/service_supervisor.rs
@@ -142,12 +142,34 @@ pub struct ServiceLogEvent {
     pub timestamp_unix_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Snapshot payload returned for a logs subscription request.
+pub enum ServiceLogSnapshot {
+    Bytes(Vec<u8>),
+    Events(Vec<ServiceLogEvent>),
+}
+
+impl ServiceLogSnapshot {
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Self::Bytes(bytes) => Some(bytes),
+            Self::Events(_) => None,
+        }
+    }
+
+    pub fn as_events(&self) -> Option<&[ServiceLogEvent]> {
+        match self {
+            Self::Bytes(_) => None,
+            Self::Events(events) => Some(events),
+        }
+    }
+}
+
 #[derive(Debug)]
 /// Result returned for a logs subscription request.
 pub struct ServiceLogSubscription {
     pub service_name: String,
-    pub snapshot_bytes: Vec<u8>,
-    pub snapshot_events: Vec<ServiceLogEvent>,
+    pub snapshot: ServiceLogSnapshot,
     pub receiver: Option<broadcast::Receiver<ServiceLogEvent>>,
 }
 
@@ -865,6 +887,7 @@ impl ServiceSupervisor {
         service_name: &str,
         tail_lines: u32,
         follow: bool,
+        with_timestamp: bool,
     ) -> Result<ServiceLogSubscription, ImagodError> {
         let running_subscription = {
             let inner = self.inner.read().await;
@@ -882,15 +905,18 @@ impl ServiceSupervisor {
         };
 
         if let Some((snapshot_source, receiver)) = running_subscription {
-            let (snapshot_bytes, snapshot_events) = {
+            let snapshot = {
                 let buffer = snapshot_source.lock().await;
-                buffer.tail_snapshot(tail_lines)
+                if with_timestamp {
+                    ServiceLogSnapshot::Events(buffer.tail_snapshot_events(tail_lines))
+                } else {
+                    ServiceLogSnapshot::Bytes(buffer.tail_snapshot_bytes(tail_lines))
+                }
             };
 
             return Ok(ServiceLogSubscription {
                 service_name: service_name.to_string(),
-                snapshot_bytes,
-                snapshot_events,
+                snapshot,
                 receiver,
             });
         }
@@ -903,8 +929,8 @@ impl ServiceSupervisor {
             ));
         }
 
-        let retained_snapshot = self.read_retained_snapshot(service_name).await?;
-        let (retained_snapshot, retained_events) = retained_snapshot.ok_or_else(|| {
+        let retained_events = self.read_retained_events(service_name).await?;
+        let retained_events = retained_events.ok_or_else(|| {
             ImagodError::new(
                 ErrorCode::NotFound,
                 STAGE_LOGS,
@@ -912,17 +938,21 @@ impl ServiceSupervisor {
             )
         })?;
 
-        let snapshot_bytes = tail_lines_from_bytes(&retained_snapshot, tail_lines);
-        let snapshot_events = tail_events_from_snapshot_bytes(
-            &retained_events,
-            &retained_snapshot,
-            snapshot_bytes.len(),
-        );
+        let snapshot = if with_timestamp {
+            ServiceLogSnapshot::Events(tail_snapshot_events_from_events(
+                &retained_events,
+                tail_lines,
+            ))
+        } else {
+            ServiceLogSnapshot::Bytes(tail_snapshot_bytes_from_events(
+                &retained_events,
+                tail_lines,
+            ))
+        };
 
         Ok(ServiceLogSubscription {
             service_name: service_name.to_string(),
-            snapshot_bytes,
-            snapshot_events,
+            snapshot,
             receiver: None,
         })
     }
@@ -1306,8 +1336,7 @@ impl ServiceSupervisor {
     ) {
         let snapshot_events = {
             let buffer = composite_log.lock().await;
-            let (_, events) = buffer.snapshot();
-            events
+            buffer.snapshot_events()
         };
 
         if let Err(err) = self
@@ -1321,15 +1350,15 @@ impl ServiceSupervisor {
         }
     }
 
-    async fn read_retained_snapshot(
+    async fn read_retained_events(
         &self,
         service_name: &str,
-    ) -> Result<Option<(Vec<u8>, Vec<ServiceLogEvent>)>, ImagodError> {
+    ) -> Result<Option<Vec<ServiceLogEvent>>, ImagodError> {
         let retained_logs = self.retained_logs.clone();
         let service_name = service_name.to_string();
         tokio::task::spawn_blocking(move || {
             let retained = retained_logs.blocking_lock();
-            retained.snapshot(&service_name)
+            retained.snapshot_events(&service_name)
         })
         .await
         .map_err(|err| {
@@ -1442,8 +1471,7 @@ async fn attach_start_failure_wasm_log_details(
 
     let snapshot_events = {
         let buffer = log_buffers.composite_log.lock().await;
-        let (_, events) = buffer.snapshot();
-        events
+        buffer.snapshot_events()
     };
 
     let stdout = collect_stream_snapshot_bytes(&snapshot_events, ServiceLogStream::Stdout);
@@ -1531,65 +1559,20 @@ fn spawn_log_drain<R>(
     );
 }
 
-fn tail_lines_from_bytes(bytes: &[u8], tail_lines: u32) -> Vec<u8> {
-    log_buffer::tail_lines_from_bytes(bytes, tail_lines)
+#[cfg(test)]
+fn snapshot_bytes_from_events(events: &[ServiceLogEvent]) -> Vec<u8> {
+    log_buffer::snapshot_bytes_from_events(events)
 }
 
-fn tail_events_from_snapshot_bytes(
+fn tail_snapshot_bytes_from_events(events: &[ServiceLogEvent], tail_lines: u32) -> Vec<u8> {
+    log_buffer::tail_snapshot_bytes_from_events(events, tail_lines)
+}
+
+fn tail_snapshot_events_from_events(
     events: &[ServiceLogEvent],
-    full_snapshot_bytes: &[u8],
-    tailed_bytes_len: usize,
+    tail_lines: u32,
 ) -> Vec<ServiceLogEvent> {
-    if tailed_bytes_len == 0 {
-        return Vec::new();
-    }
-
-    let start = full_snapshot_bytes.len().saturating_sub(tailed_bytes_len);
-    let mut skip = start;
-    let mut remaining = tailed_bytes_len;
-    let mut out = Vec::new();
-
-    for event in events {
-        if remaining == 0 {
-            break;
-        }
-        if skip >= event.bytes.len() {
-            skip = skip.saturating_sub(event.bytes.len());
-            continue;
-        }
-
-        let start = skip;
-        let available = event.bytes.len().saturating_sub(start);
-        let take = available.min(remaining);
-        if take == 0 {
-            continue;
-        }
-
-        out.push(ServiceLogEvent {
-            stream: event.stream,
-            bytes: event.bytes[start..start + take].to_vec(),
-            timestamp_unix_ms: event.timestamp_unix_ms,
-        });
-        skip = 0;
-        remaining = remaining.saturating_sub(take);
-    }
-
-    if remaining == 0 {
-        return out;
-    }
-
-    // Fall back to preserving exact tail bytes even when event boundaries are inconsistent.
-    vec![ServiceLogEvent {
-        stream: events
-            .last()
-            .map(|event| event.stream)
-            .unwrap_or(ServiceLogStream::Stdout),
-        bytes: full_snapshot_bytes[start..].to_vec(),
-        timestamp_unix_ms: events
-            .last()
-            .map(|event| event.timestamp_unix_ms)
-            .unwrap_or(0),
-    }]
+    log_buffer::tail_snapshot_events_from_events(events, tail_lines)
 }
 
 /// Sends kill signal to child and waits for termination.
@@ -1740,6 +1723,18 @@ mod tests {
         PathBuf::from(format!("/tmp/iss-{prefix}-{id}"))
     }
 
+    fn expect_snapshot_bytes(snapshot: &ServiceLogSnapshot) -> &[u8] {
+        snapshot
+            .as_bytes()
+            .expect("snapshot should be bytes-based for this assertion")
+    }
+
+    fn expect_snapshot_events(snapshot: &ServiceLogSnapshot) -> &[ServiceLogEvent] {
+        snapshot
+            .as_events()
+            .expect("snapshot should be event-based for this assertion")
+    }
+
     fn new_running_service(
         child: Child,
         runner_id: &str,
@@ -1798,10 +1793,19 @@ mod tests {
 
     #[test]
     fn bounded_log_buffer_keeps_latest_bytes_only() {
-        let mut buffer = log_buffer::BoundedLogBuffer::new(5);
-        buffer.push(b"abc");
-        buffer.push(b"def");
-        assert_eq!(buffer.len(), 5);
+        let mut buffer = log_buffer::BoundedLogEventBuffer::new(5);
+        buffer.push(ServiceLogEvent {
+            stream: ServiceLogStream::Stdout,
+            bytes: b"abc".to_vec(),
+            timestamp_unix_ms: 1,
+        });
+        buffer.push(ServiceLogEvent {
+            stream: ServiceLogStream::Stdout,
+            bytes: b"def".to_vec(),
+            timestamp_unix_ms: 2,
+        });
+        assert_eq!(buffer.total_bytes(), 5);
+        assert_eq!(buffer.snapshot_bytes(), b"bcdef");
     }
 
     #[tokio::test]
@@ -1920,17 +1924,31 @@ mod tests {
     }
 
     #[test]
-    fn tail_lines_from_bytes_returns_last_n_lines() {
-        let value = b"l1\nl2\nl3\n";
-        assert_eq!(tail_lines_from_bytes(value, 1), b"l3\n");
-        assert_eq!(tail_lines_from_bytes(value, 2), b"l2\nl3\n");
-        assert_eq!(tail_lines_from_bytes(value, 0), b"");
+    fn tail_snapshot_bytes_from_events_returns_last_n_lines() {
+        let events = vec![
+            ServiceLogEvent {
+                stream: ServiceLogStream::Stdout,
+                bytes: b"l1\n".to_vec(),
+                timestamp_unix_ms: 1,
+            },
+            ServiceLogEvent {
+                stream: ServiceLogStream::Stdout,
+                bytes: b"l2\n".to_vec(),
+                timestamp_unix_ms: 2,
+            },
+            ServiceLogEvent {
+                stream: ServiceLogStream::Stdout,
+                bytes: b"l3\n".to_vec(),
+                timestamp_unix_ms: 3,
+            },
+        ];
+        assert_eq!(tail_snapshot_bytes_from_events(&events, 1), b"l3\n");
+        assert_eq!(tail_snapshot_bytes_from_events(&events, 2), b"l2\nl3\n");
+        assert_eq!(tail_snapshot_bytes_from_events(&events, 0), b"");
     }
 
     #[test]
-    fn tail_events_from_snapshot_bytes_preserves_timestamp_for_tailed_content() {
-        let full = b"l1\nl2\nl3\n".to_vec();
-        let tailed = tail_lines_from_bytes(&full, 2);
+    fn tail_snapshot_events_from_events_preserves_timestamp_for_tailed_content() {
         let events = vec![
             ServiceLogEvent {
                 stream: ServiceLogStream::Stdout,
@@ -1949,11 +1967,9 @@ mod tests {
             },
         ];
 
-        let tailed_events = tail_events_from_snapshot_bytes(&events, &full, tailed.len());
-        let joined = tailed_events
-            .iter()
-            .flat_map(|event| event.bytes.clone())
-            .collect::<Vec<_>>();
+        let tailed = tail_snapshot_bytes_from_events(&events, 2);
+        let tailed_events = tail_snapshot_events_from_events(&events, 2);
+        let joined = snapshot_bytes_from_events(&tailed_events);
         let timestamps = tailed_events
             .iter()
             .map(|event| event.timestamp_unix_ms)
@@ -1964,22 +1980,15 @@ mod tests {
     }
 
     #[test]
-    fn tail_events_from_snapshot_bytes_preserves_full_snapshot_bytes_when_events_are_shorter() {
-        let full = b"abc\ndef\n".to_vec();
+    fn tail_snapshot_events_from_events_preserves_partial_event_timestamp() {
         let events = vec![ServiceLogEvent {
             stream: ServiceLogStream::Stdout,
-            bytes: b"def\n".to_vec(),
+            bytes: b"abc\ndef\n".to_vec(),
             timestamp_unix_ms: 10,
         }];
 
-        let tailed_events = tail_events_from_snapshot_bytes(&events, &full, full.len());
-        assert_eq!(
-            tailed_events
-                .iter()
-                .flat_map(|event| event.bytes.clone())
-                .collect::<Vec<_>>(),
-            full
-        );
+        let tailed_events = tail_snapshot_events_from_events(&events, 1);
+        assert_eq!(snapshot_bytes_from_events(&tailed_events), b"def\n");
         assert_eq!(tailed_events.len(), 1);
         assert_eq!(tailed_events[0].timestamp_unix_ms, 10);
     }
@@ -2035,18 +2044,10 @@ mod tests {
             .await
             .expect("force stop should succeed");
         let subscription = supervisor
-            .open_logs(service_name, 10, false)
+            .open_logs(service_name, 10, false, false)
             .await
             .expect("retained logs should remain available");
-        assert_eq!(subscription.snapshot_bytes.len(), 900);
-        assert_eq!(
-            subscription
-                .snapshot_events
-                .iter()
-                .flat_map(|event| event.bytes.clone())
-                .collect::<Vec<_>>(),
-            subscription.snapshot_bytes
-        );
+        assert_eq!(expect_snapshot_bytes(&subscription.snapshot).len(), 900);
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -2115,29 +2116,39 @@ mod tests {
             inner.insert(service_name.to_string(), service);
         }
 
-        let subscription = supervisor
-            .open_logs(service_name, 2, true)
+        let byte_subscription = supervisor
+            .open_logs(service_name, 2, true, false)
             .await
             .expect("open_logs should succeed");
-        assert_eq!(subscription.service_name, service_name);
-        assert_eq!(subscription.snapshot_bytes, b"b\nc\n");
+        assert_eq!(byte_subscription.service_name, service_name);
         assert_eq!(
-            subscription
-                .snapshot_events
-                .iter()
-                .flat_map(|event| event.bytes.clone())
-                .collect::<Vec<_>>(),
-            subscription.snapshot_bytes
+            expect_snapshot_bytes(&byte_subscription.snapshot),
+            b"b\nc\n"
+        );
+        assert!(
+            byte_subscription.receiver.is_some(),
+            "follow should subscribe"
+        );
+
+        let event_subscription = supervisor
+            .open_logs(service_name, 2, true, true)
+            .await
+            .expect("timestamped open_logs should succeed");
+        assert_eq!(
+            snapshot_bytes_from_events(expect_snapshot_events(&event_subscription.snapshot)),
+            b"b\nc\n"
         );
         assert_eq!(
-            subscription
-                .snapshot_events
+            expect_snapshot_events(&event_subscription.snapshot)
                 .iter()
                 .map(|event| event.timestamp_unix_ms)
                 .collect::<Vec<_>>(),
             vec![11, 12]
         );
-        assert!(subscription.receiver.is_some(), "follow should subscribe");
+        assert!(
+            event_subscription.receiver.is_some(),
+            "follow should subscribe"
+        );
 
         stop_running_service_best_effort(&supervisor.inner, service_name).await;
         let _ = std::fs::remove_dir_all(&root);
@@ -2172,7 +2183,7 @@ mod tests {
         let held_snapshot_lock = composite_log.lock().await;
         let open_task = {
             let supervisor = supervisor.clone();
-            tokio::spawn(async move { supervisor.open_logs(service_name, 10, true).await })
+            tokio::spawn(async move { supervisor.open_logs(service_name, 10, true, false).await })
         };
 
         time::timeout(Duration::from_millis(200), async {
@@ -2227,32 +2238,36 @@ mod tests {
             )
             .expect("retained upsert should succeed");
 
-        let subscription = supervisor
-            .open_logs(service_name, 2, true)
+        let byte_subscription = supervisor
+            .open_logs(service_name, 2, true, false)
             .await
             .expect("retained open_logs should succeed");
-        assert_eq!(subscription.service_name, service_name);
-        assert_eq!(subscription.snapshot_bytes, b"old-b\nold-c\n");
+        assert_eq!(byte_subscription.service_name, service_name);
         assert_eq!(
-            subscription
-                .snapshot_events
-                .iter()
-                .flat_map(|event| event.bytes.clone())
-                .collect::<Vec<_>>(),
-            subscription.snapshot_bytes
+            expect_snapshot_bytes(&byte_subscription.snapshot),
+            b"old-b\nold-c\n"
+        );
+        assert!(
+            byte_subscription.receiver.is_none(),
+            "retained logs should not provide follow receiver"
+        );
+
+        let event_subscription = supervisor
+            .open_logs(service_name, 2, true, true)
+            .await
+            .expect("timestamped retained open_logs should succeed");
+        assert_eq!(
+            snapshot_bytes_from_events(expect_snapshot_events(&event_subscription.snapshot)),
+            b"old-b\nold-c\n"
         );
         assert_eq!(
-            subscription
-                .snapshot_events
+            expect_snapshot_events(&event_subscription.snapshot)
                 .iter()
                 .map(|event| event.timestamp_unix_ms)
                 .collect::<Vec<_>>(),
             vec![22, 23]
         );
-        assert!(
-            subscription.receiver.is_none(),
-            "retained logs should not provide follow receiver"
-        );
+        assert!(event_subscription.receiver.is_none());
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -2273,7 +2288,7 @@ mod tests {
 
         let _stopping_guard = supervisor.begin_stop_service(service_name);
         let err = supervisor
-            .open_logs(service_name, 10, true)
+            .open_logs(service_name, 10, true, false)
             .await
             .expect_err("stopping service should not serve stale retained logs");
         assert_eq!(err.code, ErrorCode::NotFound);
@@ -2321,10 +2336,13 @@ mod tests {
         }
 
         let subscription = supervisor
-            .open_logs(service_name, 10, true)
+            .open_logs(service_name, 10, true, false)
             .await
             .expect("open_logs should prefer running service");
-        assert_eq!(subscription.snapshot_bytes, b"running-a\nrunning-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&subscription.snapshot),
+            b"running-a\nrunning-b\n"
+        );
         assert!(
             subscription.receiver.is_some(),
             "running logs should provide follow receiver"
@@ -2637,10 +2655,13 @@ mod tests {
         drop(inner);
 
         let retained = supervisor
-            .open_logs(service_name, 10, false)
+            .open_logs(service_name, 10, false, false)
             .await
             .expect("reclaimed service logs should be retained");
-        assert_eq!(retained.snapshot_bytes, b"reclaim-a\nreclaim-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&retained.snapshot),
+            b"reclaim-a\nreclaim-b\n"
+        );
         assert!(retained.receiver.is_none());
 
         supervisor.release_start(service_name).await;
@@ -3156,10 +3177,13 @@ mod tests {
             .await
             .expect("force stop should succeed");
         let subscription = supervisor
-            .open_logs(service_name, 10, true)
+            .open_logs(service_name, 10, true, false)
             .await
             .expect("retained logs should be available");
-        assert_eq!(subscription.snapshot_bytes, b"line-a\nline-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&subscription.snapshot),
+            b"line-a\nline-b\n"
+        );
         assert!(
             subscription.receiver.is_none(),
             "retained logs should not include follow receiver"
@@ -3214,10 +3238,13 @@ mod tests {
         assert_eq!(err.code, ErrorCode::NotFound);
 
         let subscription = supervisor
-            .open_logs(service_name, 10, true)
+            .open_logs(service_name, 10, true, false)
             .await
             .expect("retained logs should remain available");
-        assert_eq!(subscription.snapshot_bytes, b"done-a\ndone-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&subscription.snapshot),
+            b"done-a\ndone-b\n"
+        );
         assert!(subscription.receiver.is_none());
 
         let _ = std::fs::remove_dir_all(&root);
@@ -3713,10 +3740,13 @@ mod tests {
         supervisor.reap_finished().await;
 
         let subscription = supervisor
-            .open_logs(service_name, 10, true)
+            .open_logs(service_name, 10, true, false)
             .await
             .expect("reap should retain logs");
-        assert_eq!(subscription.snapshot_bytes, b"reap-a\nreap-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&subscription.snapshot),
+            b"reap-a\nreap-b\n"
+        );
         assert!(subscription.receiver.is_none());
 
         let _ = std::fs::remove_dir_all(&root);
@@ -3763,10 +3793,13 @@ mod tests {
         supervisor.reap_finished_service(service_name).await;
 
         let subscription = supervisor
-            .open_logs(service_name, 10, false)
+            .open_logs(service_name, 10, false, false)
             .await
             .expect("single-service reap should retain logs");
-        assert_eq!(subscription.snapshot_bytes, b"single-a\nsingle-b\n");
+        assert_eq!(
+            expect_snapshot_bytes(&subscription.snapshot),
+            b"single-a\nsingle-b\n"
+        );
         assert!(subscription.receiver.is_none());
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/imagod-control/src/service_supervisor/log_buffer.rs
+++ b/crates/imagod-control/src/service_supervisor/log_buffer.rs
@@ -12,141 +12,6 @@ use tokio::{
 use super::{ServiceLogEvent, ServiceLogStream};
 
 #[derive(Debug)]
-/// Bounded byte ring used for per-stream runner log capture.
-pub(super) struct BoundedLogBuffer {
-    max_bytes: usize,
-    total_bytes: usize,
-    front_offset: usize,
-    chunks: VecDeque<Vec<u8>>,
-}
-
-impl BoundedLogBuffer {
-    /// Creates a new bounded log buffer.
-    pub(super) fn new(max_bytes: usize) -> Self {
-        Self {
-            max_bytes: max_bytes.max(1),
-            total_bytes: 0,
-            front_offset: 0,
-            chunks: VecDeque::new(),
-        }
-    }
-
-    fn evict_front_bytes(&mut self, mut bytes_to_evict: usize) {
-        while bytes_to_evict > 0 {
-            let Some(front) = self.chunks.front() else {
-                break;
-            };
-            let front_len = front.len().saturating_sub(self.front_offset);
-            if front_len <= bytes_to_evict {
-                bytes_to_evict = bytes_to_evict.saturating_sub(front_len);
-                self.total_bytes = self.total_bytes.saturating_sub(front_len);
-                let _ = self.chunks.pop_front();
-                self.front_offset = 0;
-                continue;
-            }
-            self.front_offset = self.front_offset.saturating_add(bytes_to_evict);
-            self.total_bytes = self.total_bytes.saturating_sub(bytes_to_evict);
-            bytes_to_evict = 0;
-        }
-
-        if self.chunks.is_empty() {
-            self.front_offset = 0;
-            self.total_bytes = 0;
-        }
-    }
-
-    /// Appends bytes and evicts oldest data when capacity is exceeded.
-    pub(super) fn push(&mut self, chunk: &[u8]) {
-        if chunk.is_empty() {
-            return;
-        }
-
-        if chunk.len() >= self.max_bytes {
-            self.chunks.clear();
-            self.front_offset = 0;
-            let start = chunk.len().saturating_sub(self.max_bytes);
-            self.chunks.push_back(chunk[start..].to_vec());
-            self.total_bytes = self.max_bytes;
-            return;
-        }
-
-        self.total_bytes = self.total_bytes.saturating_add(chunk.len());
-        self.chunks.push_back(chunk.to_vec());
-        if self.total_bytes > self.max_bytes {
-            self.evict_front_bytes(self.total_bytes.saturating_sub(self.max_bytes));
-        }
-    }
-
-    pub(super) fn bytes_from_offset(&self, offset: usize) -> Vec<u8> {
-        if offset >= self.total_bytes {
-            return Vec::new();
-        }
-        let mut remaining_skip = offset;
-        let mut out = Vec::with_capacity(self.total_bytes.saturating_sub(offset));
-        for (index, chunk) in self.chunks.iter().enumerate() {
-            let segment = if index == 0 {
-                &chunk[self.front_offset..]
-            } else {
-                chunk.as_slice()
-            };
-            if remaining_skip >= segment.len() {
-                remaining_skip = remaining_skip.saturating_sub(segment.len());
-                continue;
-            }
-            out.extend_from_slice(&segment[remaining_skip..]);
-            remaining_skip = 0;
-        }
-        out
-    }
-
-    pub(super) fn tail_start_offset_by_lines(&self, tail_lines: u32) -> usize {
-        if tail_lines == 0 || self.total_bytes == 0 {
-            return self.total_bytes;
-        }
-
-        let keep_lines = tail_lines as usize;
-        let tracked_line_starts_limit = keep_lines.min(self.total_bytes.saturating_add(1)).max(1);
-        let mut recent_line_starts = VecDeque::with_capacity(tracked_line_starts_limit);
-        recent_line_starts.push_back(0usize);
-        let mut total_line_starts = 1usize;
-        let mut index = 0usize;
-
-        for (chunk_index, chunk) in self.chunks.iter().enumerate() {
-            let segment = if chunk_index == 0 {
-                &chunk[self.front_offset..]
-            } else {
-                chunk.as_slice()
-            };
-            for byte in segment {
-                if *byte == b'\n' && index + 1 < self.total_bytes {
-                    total_line_starts = total_line_starts.saturating_add(1);
-                    recent_line_starts.push_back(index + 1);
-                    if recent_line_starts.len() > tracked_line_starts_limit {
-                        let _ = recent_line_starts.pop_front();
-                    }
-                }
-                index = index.saturating_add(1);
-            }
-        }
-
-        if total_line_starts <= keep_lines {
-            0
-        } else {
-            recent_line_starts.front().copied().unwrap_or(0)
-        }
-    }
-
-    pub(super) fn snapshot(&self) -> Vec<u8> {
-        self.bytes_from_offset(0)
-    }
-
-    #[cfg(test)]
-    pub(super) fn len(&self) -> usize {
-        self.total_bytes
-    }
-}
-
-#[derive(Debug)]
 /// Bounded event ring used for timestamp-preserving log snapshot capture.
 pub(super) struct BoundedLogEventBuffer {
     max_bytes: usize,
@@ -205,68 +70,45 @@ impl BoundedLogEventBuffer {
         self.events.iter().cloned().collect()
     }
 
-    pub(super) fn tail_from_offset(
-        &self,
-        mut offset: usize,
-        tailed_bytes: &[u8],
-    ) -> Vec<ServiceLogEvent> {
-        if tailed_bytes.is_empty() {
-            return Vec::new();
-        }
+    #[cfg(test)]
+    pub(super) fn snapshot_bytes(&self) -> Vec<u8> {
+        materialize_bytes_from_offset(self.events.iter(), 0, self.total_bytes)
+    }
 
-        let mut remaining = tailed_bytes.len();
-        let mut out = Vec::new();
-        for event in &self.events {
-            if remaining == 0 {
-                break;
-            }
-            if offset >= event.bytes.len() {
-                offset = offset.saturating_sub(event.bytes.len());
-                continue;
-            }
-            let start = offset;
-            let available = event.bytes.len().saturating_sub(start);
-            let take = available.min(remaining);
-            if take > 0 {
-                out.push(ServiceLogEvent {
-                    stream: event.stream,
-                    bytes: event.bytes[start..start + take].to_vec(),
-                    timestamp_unix_ms: event.timestamp_unix_ms,
-                });
-                remaining = remaining.saturating_sub(take);
-            }
-            offset = 0;
-        }
+    pub(super) fn tail_snapshot_events(&self, tail_lines: u32) -> Vec<ServiceLogEvent> {
+        let start_offset =
+            compute_tail_start_offset_by_lines(self.events.iter(), self.total_bytes, tail_lines);
+        slice_events_from_offset(
+            self.events.iter(),
+            start_offset,
+            self.total_bytes.saturating_sub(start_offset),
+        )
+    }
 
-        if remaining == 0 {
-            return out;
-        }
-
-        vec![ServiceLogEvent {
-            stream: self
-                .events
-                .back()
-                .map(|event| event.stream)
-                .unwrap_or(ServiceLogStream::Stdout),
-            bytes: tailed_bytes.to_vec(),
-            timestamp_unix_ms: self
-                .events
-                .back()
-                .map(|event| event.timestamp_unix_ms)
-                .unwrap_or(0),
-        }]
+    pub(super) fn tail_snapshot_bytes(&self, tail_lines: u32) -> Vec<u8> {
+        let start_offset =
+            compute_tail_start_offset_by_lines(self.events.iter(), self.total_bytes, tail_lines);
+        materialize_bytes_from_offset(
+            self.events.iter(),
+            start_offset,
+            self.total_bytes.saturating_sub(start_offset),
+        )
     }
 
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.events.len()
     }
+
+    #[cfg(test)]
+    pub(super) fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
 }
 
 #[derive(Debug)]
-/// Bounded composite buffer keeping bytes and timestamped events in the same order.
+/// Bounded composite buffer keeping one payload-owning event ring.
 pub(super) struct CompositeLogBuffer {
-    bytes: BoundedLogBuffer,
     events: BoundedLogEventBuffer,
 }
 
@@ -274,26 +116,30 @@ impl CompositeLogBuffer {
     /// Creates a new bounded composite log buffer.
     pub(super) fn new(max_bytes: usize) -> Self {
         Self {
-            bytes: BoundedLogBuffer::new(max_bytes),
             events: BoundedLogEventBuffer::new(max_bytes),
         }
     }
 
-    /// Appends one log event to both byte and event rings in one call.
+    /// Appends one log event to the bounded event ring.
     pub(super) fn push_event(&mut self, event: ServiceLogEvent) {
-        self.bytes.push(&event.bytes);
         self.events.push(event);
     }
 
-    pub(super) fn snapshot(&self) -> (Vec<u8>, Vec<ServiceLogEvent>) {
-        (self.bytes.snapshot(), self.events.snapshot())
+    #[cfg(test)]
+    pub(super) fn snapshot_bytes(&self) -> Vec<u8> {
+        self.events.snapshot_bytes()
     }
 
-    pub(super) fn tail_snapshot(&self, tail_lines: u32) -> (Vec<u8>, Vec<ServiceLogEvent>) {
-        let start_offset = self.bytes.tail_start_offset_by_lines(tail_lines);
-        let tailed_bytes = self.bytes.bytes_from_offset(start_offset);
-        let tailed_events = self.events.tail_from_offset(start_offset, &tailed_bytes);
-        (tailed_bytes, tailed_events)
+    pub(super) fn snapshot_events(&self) -> Vec<ServiceLogEvent> {
+        self.events.snapshot()
+    }
+
+    pub(super) fn tail_snapshot_bytes(&self, tail_lines: u32) -> Vec<u8> {
+        self.events.tail_snapshot_bytes(tail_lines)
+    }
+
+    pub(super) fn tail_snapshot_events(&self, tail_lines: u32) -> Vec<ServiceLogEvent> {
+        self.events.tail_snapshot_events(tail_lines)
     }
 }
 
@@ -351,23 +197,145 @@ fn unix_timestamp_ms_now() -> u64 {
         .unwrap_or(u64::MAX)
 }
 
-pub(super) fn tail_lines_from_bytes(bytes: &[u8], tail_lines: u32) -> Vec<u8> {
-    if tail_lines == 0 || bytes.is_empty() {
-        return Vec::new();
+#[cfg(test)]
+pub(super) fn snapshot_bytes_from_events(events: &[ServiceLogEvent]) -> Vec<u8> {
+    materialize_bytes_from_offset(events.iter(), 0, total_bytes_for_events(events))
+}
+
+pub(super) fn tail_snapshot_events_from_events(
+    events: &[ServiceLogEvent],
+    tail_lines: u32,
+) -> Vec<ServiceLogEvent> {
+    let total_bytes = total_bytes_for_events(events);
+    let start_offset = compute_tail_start_offset_by_lines(events.iter(), total_bytes, tail_lines);
+    slice_events_from_offset(
+        events.iter(),
+        start_offset,
+        total_bytes.saturating_sub(start_offset),
+    )
+}
+
+pub(super) fn tail_snapshot_bytes_from_events(
+    events: &[ServiceLogEvent],
+    tail_lines: u32,
+) -> Vec<u8> {
+    let total_bytes = total_bytes_for_events(events);
+    let start_offset = compute_tail_start_offset_by_lines(events.iter(), total_bytes, tail_lines);
+    materialize_bytes_from_offset(
+        events.iter(),
+        start_offset,
+        total_bytes.saturating_sub(start_offset),
+    )
+}
+
+fn total_bytes_for_events(events: &[ServiceLogEvent]) -> usize {
+    events.iter().map(|event| event.bytes.len()).sum()
+}
+
+fn compute_tail_start_offset_by_lines<'a, I>(
+    events: I,
+    total_bytes: usize,
+    tail_lines: u32,
+) -> usize
+where
+    I: IntoIterator<Item = &'a ServiceLogEvent>,
+{
+    if tail_lines == 0 || total_bytes == 0 {
+        return total_bytes;
     }
 
-    let mut line_starts = vec![0usize];
-    for (idx, byte) in bytes.iter().enumerate() {
-        if *byte == b'\n' && idx + 1 < bytes.len() {
-            line_starts.push(idx + 1);
+    let keep_lines = tail_lines as usize;
+    let tracked_line_starts_limit = keep_lines.min(total_bytes.saturating_add(1)).max(1);
+    let mut recent_line_starts = VecDeque::with_capacity(tracked_line_starts_limit);
+    recent_line_starts.push_back(0usize);
+    let mut total_line_starts = 1usize;
+    let mut index = 0usize;
+
+    for event in events {
+        for byte in &event.bytes {
+            if *byte == b'\n' && index + 1 < total_bytes {
+                total_line_starts = total_line_starts.saturating_add(1);
+                recent_line_starts.push_back(index + 1);
+                if recent_line_starts.len() > tracked_line_starts_limit {
+                    let _ = recent_line_starts.pop_front();
+                }
+            }
+            index = index.saturating_add(1);
         }
     }
 
-    if tail_lines as usize >= line_starts.len() {
-        return bytes.to_vec();
+    if total_line_starts <= keep_lines {
+        0
+    } else {
+        recent_line_starts.front().copied().unwrap_or(0)
     }
-    let start = line_starts[line_starts.len() - tail_lines as usize];
-    bytes[start..].to_vec()
+}
+
+fn materialize_bytes_from_offset<'a, I>(events: I, mut offset: usize, remaining: usize) -> Vec<u8>
+where
+    I: IntoIterator<Item = &'a ServiceLogEvent>,
+{
+    if remaining == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(remaining);
+    let mut remaining = remaining;
+    for event in events {
+        if remaining == 0 {
+            break;
+        }
+        if offset >= event.bytes.len() {
+            offset = offset.saturating_sub(event.bytes.len());
+            continue;
+        }
+
+        let start = offset;
+        let take = event.bytes.len().saturating_sub(start).min(remaining);
+        out.extend_from_slice(&event.bytes[start..start + take]);
+        offset = 0;
+        remaining = remaining.saturating_sub(take);
+    }
+
+    out
+}
+
+fn slice_events_from_offset<'a, I>(
+    events: I,
+    mut offset: usize,
+    mut remaining: usize,
+) -> Vec<ServiceLogEvent>
+where
+    I: IntoIterator<Item = &'a ServiceLogEvent>,
+{
+    if remaining == 0 {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for event in events {
+        if remaining == 0 {
+            break;
+        }
+        if offset >= event.bytes.len() {
+            offset = offset.saturating_sub(event.bytes.len());
+            continue;
+        }
+
+        let start = offset;
+        let take = event.bytes.len().saturating_sub(start).min(remaining);
+        if take > 0 {
+            out.push(ServiceLogEvent {
+                stream: event.stream,
+                bytes: event.bytes[start..start + take].to_vec(),
+                timestamp_unix_ms: event.timestamp_unix_ms,
+            });
+        }
+        offset = 0;
+        remaining = remaining.saturating_sub(take);
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -423,8 +391,10 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
-                let (composite_snapshot, composite_events_snapshot) =
-                    { composite.lock().await.snapshot() };
+                let (composite_snapshot, composite_events_snapshot) = {
+                    let guard = composite.lock().await;
+                    (guard.snapshot_bytes(), guard.snapshot_events())
+                };
                 if composite_snapshot == expected && !composite_events_snapshot.is_empty() {
                     break;
                 }
@@ -449,7 +419,8 @@ mod tests {
             timestamp_unix_ms: 2,
         });
 
-        let (snapshot_bytes, snapshot_events) = buffer.snapshot();
+        let snapshot_bytes = buffer.snapshot_bytes();
+        let snapshot_events = buffer.snapshot_events();
         assert_eq!(
             snapshot_events
                 .iter()
@@ -487,28 +458,25 @@ mod tests {
             b"bcdef"
         );
         assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.total_bytes(), 5);
     }
 
     #[test]
-    fn bounded_log_buffer_evicts_with_chunk_aware_front_offset() {
-        let mut buffer = BoundedLogBuffer::new(5);
-        buffer.push(b"abc");
-        buffer.push(b"def");
+    fn snapshot_bytes_from_events_preserves_joined_bytes() {
+        let events = vec![
+            ServiceLogEvent {
+                stream: ServiceLogStream::Stdout,
+                bytes: b"abc".to_vec(),
+                timestamp_unix_ms: 1,
+            },
+            ServiceLogEvent {
+                stream: ServiceLogStream::Stderr,
+                bytes: b"def".to_vec(),
+                timestamp_unix_ms: 2,
+            },
+        ];
 
-        assert_eq!(buffer.snapshot(), b"bcdef");
-        assert_eq!(buffer.len(), 5);
-        assert_eq!(buffer.front_offset, 1);
-        assert_eq!(buffer.chunks.len(), 2);
-    }
-
-    #[test]
-    fn bounded_log_buffer_large_chunk_keeps_latest_tail_only() {
-        let mut buffer = BoundedLogBuffer::new(4);
-        buffer.push(b"0123456789");
-
-        assert_eq!(buffer.snapshot(), b"6789");
-        assert_eq!(buffer.front_offset, 0);
-        assert_eq!(buffer.chunks.len(), 1);
+        assert_eq!(snapshot_bytes_from_events(&events), b"abcdef");
     }
 
     #[test]
@@ -530,7 +498,8 @@ mod tests {
             timestamp_unix_ms: 3,
         });
 
-        let (tail_bytes, tail_events) = buffer.tail_snapshot(2);
+        let tail_bytes = buffer.tail_snapshot_bytes(2);
+        let tail_events = buffer.tail_snapshot_events(2);
         assert_eq!(tail_bytes, b"line-2\nline-3\n");
         assert_eq!(
             tail_events
@@ -544,12 +513,16 @@ mod tests {
     }
 
     #[test]
-    fn bounded_log_buffer_tail_lines_with_huge_request_returns_full_snapshot() {
-        let mut buffer = BoundedLogBuffer::new(64);
-        buffer.push(b"line-1\nline-2\nline-3");
+    fn tail_snapshot_bytes_from_events_with_huge_request_returns_full_snapshot() {
+        let events = vec![ServiceLogEvent {
+            stream: ServiceLogStream::Stdout,
+            bytes: b"line-1\nline-2\nline-3".to_vec(),
+            timestamp_unix_ms: 1,
+        }];
 
-        let start_offset = buffer.tail_start_offset_by_lines(u32::MAX);
-        assert_eq!(start_offset, 0);
-        assert_eq!(buffer.bytes_from_offset(start_offset), buffer.snapshot());
+        assert_eq!(
+            tail_snapshot_bytes_from_events(&events, u32::MAX),
+            snapshot_bytes_from_events(&events)
+        );
     }
 }

--- a/crates/imagod-control/src/service_supervisor/retained_file_store.rs
+++ b/crates/imagod-control/src/service_supervisor/retained_file_store.rs
@@ -21,7 +21,6 @@ use super::{STAGE_LOGS, ServiceLogEvent, ServiceLogStream};
 
 const STORE_FILE_EXTENSION: &str = "cbor";
 const STORED_RETAINED_LOG_VERSION: u32 = 1;
-type RetainedSnapshot = (Vec<u8>, Vec<ServiceLogEvent>);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct StoredRetainedLog {
@@ -166,10 +165,10 @@ impl RetainedFileLogStore {
         self.evict_if_needed()
     }
 
-    pub(super) fn snapshot(
+    pub(super) fn snapshot_events(
         &self,
         service_name: &str,
-    ) -> Result<Option<RetainedSnapshot>, ImagodError> {
+    ) -> Result<Option<Vec<ServiceLogEvent>>, ImagodError> {
         let Some(entry) = self.entries.get(service_name) else {
             return Ok(None);
         };
@@ -204,11 +203,7 @@ impl RetainedFileLogStore {
                 timestamp_unix_ms: event.timestamp_unix_ms,
             })
             .collect();
-        let mut snapshot_bytes = Vec::new();
-        for event in &events {
-            snapshot_bytes.extend_from_slice(&event.bytes);
-        }
-        Ok(Some((snapshot_bytes, events)))
+        Ok(Some(events))
     }
 
     #[cfg(test)]
@@ -486,8 +481,8 @@ mod tests {
             .upsert("svc-a", &events)
             .expect("upsert should persist snapshot");
 
-        let (snapshot_bytes, loaded_events) = store
-            .snapshot("svc-a")
+        let loaded_events = store
+            .snapshot_events("svc-a")
             .expect("snapshot read should succeed")
             .expect("snapshot should exist");
         assert_eq!(loaded_events, events);
@@ -496,7 +491,7 @@ mod tests {
                 .iter()
                 .flat_map(|event| event.bytes.clone())
                 .collect::<Vec<_>>(),
-            snapshot_bytes
+            b"a-out\na-err\n"
         );
 
         let _ = fs::remove_dir_all(root);
@@ -515,11 +510,15 @@ mod tests {
             .upsert("svc-a", &sample_events("new", 2))
             .expect("second upsert should replace existing file");
 
-        let (snapshot_bytes, _) = store
-            .snapshot("svc-a")
+        let snapshot_events = store
+            .snapshot_events("svc-a")
             .expect("snapshot read should succeed")
             .expect("snapshot should exist");
-        assert!(String::from_utf8_lossy(&snapshot_bytes).contains("new-out"));
+        let joined = snapshot_events
+            .iter()
+            .flat_map(|event| event.bytes.clone())
+            .collect::<Vec<_>>();
+        assert!(String::from_utf8_lossy(&joined).contains("new-out"));
 
         let lingering_tmp = fs::read_dir(store.retained_dir())
             .expect("retained dir should be readable")
@@ -541,7 +540,7 @@ mod tests {
         fs::write(&path, b"not-cbor").expect("corrupt payload should be written");
 
         let err = store
-            .snapshot("svc-a")
+            .snapshot_events("svc-a")
             .expect_err("corrupt payload should map to internal error");
         assert_eq!(err.code, ErrorCode::Internal);
         assert_eq!(err.stage, STAGE_LOGS);
@@ -587,7 +586,7 @@ mod tests {
         );
         assert!(
             store
-                .snapshot("svc-c")
+                .snapshot_events("svc-c")
                 .expect("latest snapshot read should succeed")
                 .is_some(),
             "newest snapshot should remain after eviction"
@@ -613,10 +612,14 @@ mod tests {
         let store = RetainedFileLogStore::new(&root, 4096).expect("store should re-init");
         let names = store.service_names();
         assert_eq!(names, vec!["svc-persist".to_string()]);
-        let (bytes, events) = store
-            .snapshot("svc-persist")
+        let events = store
+            .snapshot_events("svc-persist")
             .expect("snapshot read should succeed")
             .expect("snapshot should exist");
+        let bytes = events
+            .iter()
+            .flat_map(|event| event.bytes.clone())
+            .collect::<Vec<_>>();
         assert!(
             String::from_utf8_lossy(&bytes).contains("persist-out"),
             "persisted bytes should be available after restart"
@@ -649,7 +652,7 @@ mod tests {
         );
         assert!(
             store
-                .snapshot("svc-a")
+                .snapshot_events("svc-a")
                 .expect("snapshot read should succeed")
                 .is_some(),
             "retained snapshot should survive startup cleanup"

--- a/crates/imagod-server/src/protocol_handler/bench_internals.rs
+++ b/crates/imagod-server/src/protocol_handler/bench_internals.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use imagod_common::ImagodError;
-use imagod_control::{ServiceLogEvent, ServiceLogStream, ServiceLogSubscription};
+use imagod_control::{ServiceLogSnapshot, ServiceLogSubscription};
 use tokio::sync::Notify;
 use uuid::Uuid;
 
@@ -111,12 +111,7 @@ pub async fn bench_forward_snapshot_datagrams(snapshot_len: usize) -> usize {
     }
     let subscriptions = vec![ServiceLogSubscription {
         service_name: "svc-bench".to_string(),
-        snapshot_bytes: snapshot.clone(),
-        snapshot_events: vec![ServiceLogEvent {
-            stream: ServiceLogStream::Stdout,
-            bytes: snapshot,
-            timestamp_unix_ms: 1,
-        }],
+        snapshot: ServiceLogSnapshot::Bytes(snapshot),
         receiver: None,
     }];
 

--- a/crates/imagod-server/src/protocol_handler/logs_forwarder.rs
+++ b/crates/imagod-server/src/protocol_handler/logs_forwarder.rs
@@ -6,7 +6,9 @@ use imago_protocol::{
     LogChunk, LogEnd, LogError, LogErrorCode, LogStreamKind, MessageType, ProtocolEnvelope, to_cbor,
 };
 use imagod_common::ImagodError;
-use imagod_control::{ServiceLogEvent, ServiceLogStream, ServiceLogSubscription};
+use imagod_control::{
+    ServiceLogEvent, ServiceLogSnapshot, ServiceLogStream, ServiceLogSubscription,
+};
 use tokio::{sync::mpsc, time::Duration};
 use uuid::Uuid;
 
@@ -302,30 +304,47 @@ where
     S: ProtocolSession,
 {
     for subscription in &subscriptions {
-        if sender.with_timestamp {
-            for event in &subscription.snapshot_events {
+        match &subscription.snapshot {
+            ServiceLogSnapshot::Bytes(bytes) => {
                 sender
                     .send_log_data_chunks(
                         seq,
                         &subscription.service_name,
                         LogStreamKind::Composite,
-                        &event.bytes,
-                        Some(event.timestamp_unix_ms),
+                        bytes,
+                        None,
                         last_name,
                     )
                     .await?;
             }
-        } else {
-            sender
-                .send_log_data_chunks(
-                    seq,
-                    &subscription.service_name,
-                    LogStreamKind::Composite,
-                    &subscription.snapshot_bytes,
-                    None,
-                    last_name,
-                )
-                .await?;
+            ServiceLogSnapshot::Events(events) => {
+                if sender.with_timestamp {
+                    for event in events {
+                        sender
+                            .send_log_data_chunks(
+                                seq,
+                                &subscription.service_name,
+                                LogStreamKind::Composite,
+                                &event.bytes,
+                                Some(event.timestamp_unix_ms),
+                                last_name,
+                            )
+                            .await?;
+                    }
+                } else {
+                    let bytes = flatten_log_event_bytes(events);
+                    sender
+                        .send_log_data_chunks(
+                            seq,
+                            &subscription.service_name,
+                            LogStreamKind::Composite,
+                            &bytes,
+                            None,
+                            last_name,
+                        )
+                        .await?;
+                }
+            }
         }
     }
 
@@ -429,6 +448,15 @@ where
 
 pub(crate) fn advance_seq_for_lagged(seq: &mut u64, dropped: u64) {
     *seq = seq.saturating_add(dropped);
+}
+
+fn flatten_log_event_bytes(events: &[ServiceLogEvent]) -> Vec<u8> {
+    let total = events.iter().map(|event| event.bytes.len()).sum();
+    let mut out = Vec::with_capacity(total);
+    for event in events {
+        out.extend_from_slice(&event.bytes);
+    }
+    out
 }
 
 async fn send_datagram_envelope<S, T>(
@@ -669,12 +697,7 @@ mod tests {
     fn sample_subscription(name: &str, snapshot_bytes: &[u8]) -> ServiceLogSubscription {
         ServiceLogSubscription {
             service_name: name.to_string(),
-            snapshot_bytes: snapshot_bytes.to_vec(),
-            snapshot_events: vec![ServiceLogEvent {
-                stream: ServiceLogStream::Stdout,
-                bytes: snapshot_bytes.to_vec(),
-                timestamp_unix_ms: 123,
-            }],
+            snapshot: ServiceLogSnapshot::Bytes(snapshot_bytes.to_vec()),
             receiver: None,
         }
     }
@@ -960,8 +983,7 @@ mod tests {
 
         let subscriptions = vec![ServiceLogSubscription {
             service_name: "svc-follow".to_string(),
-            snapshot_bytes: Vec::new(),
-            snapshot_events: Vec::new(),
+            snapshot: ServiceLogSnapshot::Bytes(Vec::new()),
             receiver: Some(rx),
         }];
         stream_logs_datagrams(&session, &sender, subscriptions, &mut seq, &mut last_name)

--- a/crates/imagod-server/src/protocol_handler/router.rs
+++ b/crates/imagod-server/src/protocol_handler/router.rs
@@ -333,7 +333,7 @@ impl ProtocolHandler {
         for service_name in &service_names {
             let subscription = self
                 .orchestrator
-                .open_logs(service_name, tail_lines, follow)
+                .open_logs(service_name, tail_lines, follow, with_timestamp)
                 .await?;
             subscriptions.push(subscription);
         }

--- a/docs/imagod-configuration.md
+++ b/docs/imagod-configuration.md
@@ -236,11 +236,32 @@ runner_ready_timeout_secs = 3
 - Required/Optional: Optional.
 - Accepted values / Constraints: `>= 1`.
 - Default: `262144`.
+- Behavior notes:
+  - Defines the total live log payload retained in manager memory for one running service.
+  - This budget applies to running-service capture only; stopped-service retained logs are governed separately by `retained_logs_capacity_bytes`.
 - Example:
 
 ```toml
 [runtime]
 runner_log_buffer_bytes = 262144
+```
+
+- Validation error notes: zero fails validation.
+
+### The `retained_logs_capacity_bytes` field
+
+- Type: `integer` (`usize`)
+- Required/Optional: Optional.
+- Accepted values / Constraints: `>= 1`.
+- Default: `524288`.
+- Behavior notes:
+  - Defines the total file-backed retained-log capacity for stopped services.
+  - This budget is tracked by manager metadata in memory, but the retained log payload itself is stored on disk under the runtime storage root.
+- Example:
+
+```toml
+[runtime]
+retained_logs_capacity_bytes = 524288
 ```
 
 - Validation error notes: zero fails validation.


### PR DESCRIPTION
## Motivation
- imagod の非 WASM 常駐メモリで支配的だった manager 側 live log 保持を削減し、1 サービスあたりの resident footprint を下げるためです。
- 既存実装は live log payload を bytes ring と event ring に二重保持しており、`runner_log_buffer_bytes` に対して実効の保持量が膨らんでいました。

## Summary
- manager/control 側の live log 保持を `ServiceLogEvent` 単一所有へ寄せ、`CompositeLogBuffer` から bytes/event の二重 payload 保持を除去しました。
- `ServiceLogSubscription` を shape-aware な snapshot enum に変更し、`open_logs` と retained log 読み出しで bytes-only または events-only のどちらかだけを生成するようにしました。
- `logs_forwarder` / `router` / bench path を新しい snapshot 形へ追従させ、[docs/imagod-configuration.md](docs/imagod-configuration.md) で `runner_log_buffer_bytes` と `retained_logs_capacity_bytes` の意味を明確化しました。

## Validation
- `cargo fmt --all`
  - Passed.
- `cargo clippy --workspace --all-targets -- -D warnings`
  - Passed.
- `cargo test --workspace`
  - Passed.
- `cargo fmt --all`
  - Passed as final formatting pass after verification.
