### PR TITLE
fix(prup): normalize pre-1.0 breaking bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ imagod-server = { path = "crates/imagod-server", version = "0.1.0" }
 base_ref = "origin/main"
 bump_strategy = "conventional_commits"
 default_bump = "patch"
+pre_1_0_breaking_bump = "minor"
 baseline_tag_required = true
 allow_dirty = false
 github_prerelease = true

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ flowchart LR
 - release PR では version bump 後に `cargo check --workspace` を実行し、`schemas/imago.schema.json` / `schemas/imagod.schema.json` の生成差分も同じ commit に含めます。
   特に `imagod` line は `server_version` default が crate version に追従するため、`schemas/imagod.schema.json` が更新対象になりえます。
 - 設定の source-of-truth は root `Cargo.toml` の `[workspace.metadata.prup]` です。
+- imago は pre-1.0 運用中のため、`pre_1_0_breaking_bump = "minor"` を設定しています。
+  `feat!:` / `BREAKING CHANGE` があっても `0.x.y` の間は `0.(x+1).0` へ上げ、`1.0.0` にはしません。
 - `[workspace.metadata.prup.crates]` は top crate のみを手動定義します。
   内部 crate は `cargo metadata` の依存グラフから自動検出されます。
 - release PR の GitHub label は `[workspace.metadata.prup.github.release_pr]` で管理します。

--- a/tools/prup/src/config.rs
+++ b/tools/prup/src/config.rs
@@ -42,6 +42,8 @@ pub struct PrupConfig {
     pub bump_strategy: String,
     #[serde(default = "default_bump")]
     pub default_bump: String,
+    #[serde(default = "default_pre_1_0_breaking_bump")]
+    pub pre_1_0_breaking_bump: String,
     #[serde(default = "default_true")]
     pub baseline_tag_required: bool,
     #[serde(default)]
@@ -140,6 +142,10 @@ fn default_bump_strategy() -> String {
 
 fn default_bump() -> String {
     "patch".to_string()
+}
+
+fn default_pre_1_0_breaking_bump() -> String {
+    "major".to_string()
 }
 
 const fn default_true() -> bool {
@@ -328,6 +334,13 @@ fn validate_config(config: &PrupConfig) -> Result<()> {
         ));
     }
 
+    if !matches!(config.pre_1_0_breaking_bump.as_str(), "minor" | "major") {
+        return Err(anyhow!(
+            "pre_1_0_breaking_bump must be one of minor/major, got {}",
+            config.pre_1_0_breaking_bump
+        ));
+    }
+
     Ok(())
 }
 
@@ -354,6 +367,7 @@ mod tests {
             base_ref: "origin/main".to_string(),
             bump_strategy: "conventional_commits".to_string(),
             default_bump: "patch".to_string(),
+            pre_1_0_breaking_bump: "major".to_string(),
             baseline_tag_required: true,
             allow_dirty: false,
             github_prerelease: true,
@@ -462,6 +476,27 @@ mod tests {
             error
                 .to_string()
                 .contains("shared_line references unknown line")
+        );
+    }
+
+    #[test]
+    fn accepts_minor_pre_1_0_breaking_bump() {
+        let mut config = sample_config();
+        config.pre_1_0_breaking_bump = "minor".to_string();
+        validate_config(&config).expect("minor pre_1_0_breaking_bump should validate");
+    }
+
+    #[test]
+    fn rejects_unknown_pre_1_0_breaking_bump() {
+        let mut config = sample_config();
+        config.pre_1_0_breaking_bump = "patch".to_string();
+
+        let error =
+            validate_config(&config).expect_err("invalid pre_1_0_breaking_bump should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("pre_1_0_breaking_bump must be one of minor/major")
         );
     }
 }

--- a/tools/prup/src/planner.rs
+++ b/tools/prup/src/planner.rs
@@ -154,6 +154,11 @@ pub fn build_plan_from_line_scopes(
 ) -> Result<ReleasePlan> {
     let default_bump = BumpLevel::from_config(&config.default_bump)?;
     let crate_map = config.crate_map();
+    let emit_tag_crates_by_line: BTreeMap<&str, &CratePolicy> = config
+        .emit_tag_crates()
+        .into_iter()
+        .map(|crate_policy| (crate_policy.line.as_str(), crate_policy))
+        .collect();
 
     let mut line_base_refs: BTreeMap<String, String> = BTreeMap::new();
     let mut changed_files_union: BTreeSet<String> = BTreeSet::new();
@@ -193,7 +198,17 @@ pub fn build_plan_from_line_scopes(
             continue;
         }
 
-        let bump = detect_bump_from_commits(&line_scope.commit_messages).unwrap_or(default_bump);
+        let bump = match detect_bump_from_commits(&line_scope.commit_messages) {
+            Some(detected) => normalize_bump_for_line_version(
+                config,
+                workspace,
+                workspace_version,
+                &emit_tag_crates_by_line,
+                &line_scope.line_id,
+                detected,
+            )?,
+            None => default_bump,
+        };
         line_bumps
             .entry(line_scope.line_id.clone())
             .and_modify(|current| *current = (*current).max(bump))
@@ -575,6 +590,65 @@ pub fn detect_bump_from_commits(messages: &[String]) -> Option<BumpLevel> {
     detected
 }
 
+fn normalize_bump_for_line_version(
+    config: &ResolvedPolicy,
+    workspace: &WorkspaceInfo,
+    workspace_version: &Version,
+    emit_tag_crates_by_line: &BTreeMap<&str, &CratePolicy>,
+    line_id: &str,
+    detected: BumpLevel,
+) -> Result<BumpLevel> {
+    let current_version = current_line_version(
+        workspace,
+        workspace_version,
+        emit_tag_crates_by_line,
+        line_id,
+    )?;
+    Ok(normalize_bump_for_version(
+        detected,
+        &current_version,
+        &config.pre_1_0_breaking_bump,
+    ))
+}
+
+fn current_line_version(
+    workspace: &WorkspaceInfo,
+    workspace_version: &Version,
+    emit_tag_crates_by_line: &BTreeMap<&str, &CratePolicy>,
+    line_id: &str,
+) -> Result<Version> {
+    let crate_policy = emit_tag_crates_by_line
+        .get(line_id)
+        .ok_or_else(|| anyhow!("line {} does not have an emit_tag crate", line_id))?;
+
+    match crate_policy.version_source {
+        VersionSource::Workspace => Ok(workspace_version.clone()),
+        VersionSource::Package => workspace
+            .package(&crate_policy.name)
+            .map(|package| package.version.clone())
+            .ok_or_else(|| anyhow!("package {} not found", crate_policy.name)),
+        VersionSource::None => Err(anyhow!(
+            "emit_tag crate {} cannot use version_source=none",
+            crate_policy.name
+        )),
+    }
+}
+
+fn normalize_bump_for_version(
+    detected: BumpLevel,
+    current_version: &Version,
+    pre_1_0_breaking_bump: &str,
+) -> BumpLevel {
+    if detected == BumpLevel::Major
+        && current_version.major == 0
+        && pre_1_0_breaking_bump == "minor"
+    {
+        BumpLevel::Minor
+    } else {
+        detected
+    }
+}
+
 fn impacted_source_lines(
     impacted_crates: &BTreeSet<String>,
     crate_map: &BTreeMap<&str, &CratePolicy>,
@@ -720,6 +794,7 @@ mod tests {
         ResolvedPolicy {
             base_ref: "origin/main".to_string(),
             default_bump: "patch".to_string(),
+            pre_1_0_breaking_bump: "minor".to_string(),
             baseline_tag_required: true,
             allow_dirty: false,
             github_prerelease: true,
@@ -1018,6 +1093,121 @@ mod tests {
             "feat!: change api".to_string(),
         ]);
         assert_eq!(detected, Some(BumpLevel::Major));
+    }
+
+    #[test]
+    fn pre_1_0_minor_policy_normalizes_major_bump() {
+        let normalized = normalize_bump_for_version(
+            BumpLevel::Major,
+            &Version::parse("0.1.1").expect("version should parse"),
+            "minor",
+        );
+        assert_eq!(normalized, BumpLevel::Minor);
+    }
+
+    #[test]
+    fn pre_1_0_major_policy_keeps_major_bump() {
+        let normalized = normalize_bump_for_version(
+            BumpLevel::Major,
+            &Version::parse("0.1.1").expect("version should parse"),
+            "major",
+        );
+        assert_eq!(normalized, BumpLevel::Major);
+    }
+
+    #[test]
+    fn post_1_0_breaking_stays_major() {
+        let normalized = normalize_bump_for_version(
+            BumpLevel::Major,
+            &Version::parse("1.2.3").expect("version should parse"),
+            "minor",
+        );
+        assert_eq!(normalized, BumpLevel::Major);
+    }
+
+    #[test]
+    fn breaking_commit_uses_minor_for_pre_1_0_lines_when_configured() {
+        let config = sample_policy();
+        let workspace = sample_workspace();
+        let workspace_version = Version::parse("0.1.0").expect("workspace version should parse");
+
+        let plan = build_plan_from_line_scopes(
+            &config,
+            &workspace,
+            &workspace_version,
+            &[
+                LineScopeInput {
+                    line_id: "imago-cli".to_string(),
+                    base_ref: "imago-v0.2.0".to_string(),
+                    changed_files: vec![PathBuf::from("imago-project-config/src/lib.rs")],
+                    commit_messages: vec!["feat!: change cli api".to_string()],
+                },
+                LineScopeInput {
+                    line_id: "imagod-daemon".to_string(),
+                    base_ref: "imagod-v0.1.0".to_string(),
+                    changed_files: vec![PathBuf::from("imagod-common/src/lib.rs")],
+                    commit_messages: vec!["BREAKING CHANGE: daemon api".to_string()],
+                },
+            ],
+        )
+        .expect("plan should build");
+
+        let line_bumps: BTreeMap<String, BumpLevel> = plan
+            .line_bumps
+            .iter()
+            .map(|item| (item.line_id.clone(), item.bump))
+            .collect();
+        assert_eq!(line_bumps.get("imago-cli"), Some(&BumpLevel::Minor));
+        assert_eq!(line_bumps.get("imagod-daemon"), Some(&BumpLevel::Minor));
+
+        let cli_update = plan
+            .package_version_updates
+            .iter()
+            .find(|update| update.crate_name == "imago-cli")
+            .expect("cli update should exist");
+        assert_eq!(cli_update.after, "0.3.0");
+        assert_eq!(cli_update.bump, BumpLevel::Minor);
+
+        let workspace_update = plan
+            .workspace_version_update
+            .as_ref()
+            .expect("workspace update should exist");
+        assert_eq!(workspace_update.after, "0.2.0");
+        assert_eq!(workspace_update.bump, BumpLevel::Minor);
+
+        let target =
+            build_release_pr_target(&config, &plan, "imagod-daemon").expect("target should build");
+        assert_eq!(target.bump, BumpLevel::Minor);
+        assert!(target.body.contains("- Bump: `minor`"));
+        assert_eq!(target.after_version, "0.2.0");
+    }
+
+    #[test]
+    fn default_major_policy_preserves_pre_1_0_major_bump() {
+        let mut config = sample_policy();
+        config.pre_1_0_breaking_bump = "major".to_string();
+        let workspace = sample_workspace();
+        let workspace_version = Version::parse("0.1.0").expect("workspace version should parse");
+
+        let plan = build_plan_from_line_scopes(
+            &config,
+            &workspace,
+            &workspace_version,
+            &[LineScopeInput {
+                line_id: "imagod-daemon".to_string(),
+                base_ref: "imagod-v0.1.0".to_string(),
+                changed_files: vec![PathBuf::from("imagod-common/src/lib.rs")],
+                commit_messages: vec!["feat!: change daemon api".to_string()],
+            }],
+        )
+        .expect("plan should build");
+
+        let workspace_update = plan
+            .workspace_version_update
+            .as_ref()
+            .expect("workspace update should exist");
+        assert_eq!(workspace_update.bump, BumpLevel::Major);
+        assert_eq!(workspace_update.after, "1.0.0");
     }
 
     #[test]

--- a/tools/prup/src/resolver.rs
+++ b/tools/prup/src/resolver.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 pub struct ResolvedPolicy {
     pub base_ref: String,
     pub default_bump: String,
+    pub pre_1_0_breaking_bump: String,
     pub baseline_tag_required: bool,
     pub allow_dirty: bool,
     pub github_prerelease: bool,
@@ -77,6 +78,7 @@ pub fn resolve(config: &PrupConfig, workspace: &WorkspaceInfo) -> Result<Resolve
     Ok(ResolvedPolicy {
         base_ref: config.base_ref.clone(),
         default_bump: config.default_bump.clone(),
+        pre_1_0_breaking_bump: config.pre_1_0_breaking_bump.clone(),
         baseline_tag_required: config.baseline_tag_required,
         allow_dirty: config.allow_dirty,
         github_prerelease: config.github_prerelease,
@@ -216,6 +218,7 @@ mod tests {
             base_ref: "origin/main".to_string(),
             bump_strategy: "conventional_commits".to_string(),
             default_bump: "patch".to_string(),
+            pre_1_0_breaking_bump: "major".to_string(),
             baseline_tag_required: true,
             allow_dirty: false,
             github_prerelease: true,


### PR DESCRIPTION
## Motivation
- `prup` が `feat!:` / `BREAKING CHANGE` を無条件で `major` として適用しており、imago の current version (`0.x.y`) でも `1.0.0` へ上がっていました。
- imago では pre-1.0 の間は breaking change でも `0.(x+1).0` に上げる運用にしたいため、repo 側設定でそのルールを固定する必要がありました。

## Summary
- `prup` に `pre_1_0_breaking_bump` 設定を追加し、default は既存互換の `major` にしました。
- planner で line の current version を見て effective bump を正規化し、`0.x.y` かつ `pre_1_0_breaking_bump = "minor"` の場合は breaking change を `minor` として適用するようにしました。
- `plan` / `release-pr-targets` / `explain` / release PR body が normalized bump を表示するように揃えました。
- imago の root `Cargo.toml` に `pre_1_0_breaking_bump = "minor"` を設定し、docs の release contract に pre-1.0 bump 運用を追記しました。

## Validation
- `cargo fmt --all`
  - Passed
- `cargo clippy --workspace --all-targets -- -D warnings`
  - Passed
- `cargo test --workspace`
  - Passed
- `cargo check -p prup`
  - Passed
- `cargo test -p prup`
  - Passed (24 tests)
- `cargo run -p prup -- plan --allow-dirty`
  - Passed
  - `imago-cli (Minor)`
  - `imagod-daemon (Minor)`
  - `workspace.version: 0.1.0 -> 0.2.0`
  - `imago-cli: 0.1.1 -> 0.2.0`
- `cargo run -p prup -- release-pr-targets --format json --allow-dirty`
  - Passed
  - `ci(release): imago-cli 0.1.1 -> 0.2.0`
  - `ci(release): imagod 0.1.0 -> 0.2.0`
  - both targets emit `bump: "minor"`
- `cargo run -p prup -- explain --allow-dirty imagod-daemon`
  - Passed
  - `line \`imagod-daemon\` は Minor bump です。`
