### PR TITLE
fix: configure git identity for prup release

### DIFF
--- a/.github/actions/prup-release/run.sh
+++ b/.github/actions/prup-release/run.sh
@@ -12,6 +12,9 @@ if jq -e '.targets | length == 0' "$targets_json" >/dev/null; then
   exit 0
 fi
 
+git config user.name "prup[bot]"
+git config user.email "prup[bot]@users.noreply.github.com"
+
 prerelease_flag="$(jq -r '.prerelease' "$targets_json")"
 
 while IFS= read -r row; do


### PR DESCRIPTION
## Motivation
- `prup-release.yml` の `prup release` job が `.github/actions/prup-release/run.sh` 内の `git tag -a` 実行時に Git identity 未設定で失敗していました。
- 実際の失敗 run `22764442213` では `Committer identity unknown` と `fatal: empty ident name` が出ており、後続の `prup release-pr` job も skip されていました。

## Summary
- `.github/actions/prup-release/run.sh` に repo-local の Git identity 設定を追加しました。
- `prup-release-pr` と同じ `prup[bot] / prup[bot]@users.noreply.github.com` を使い、annotated tag 作成前にだけ最小設定する形に揃えました。
- 変更範囲は release action の shell 1 ファイルのみで、`prup` CLI / workflow input / release PR 契約は変更していません。

## Validation
- `bash -n .github/actions/prup-release/run.sh` : success
- `bash -n .github/actions/prup-release-pr/run.sh` : success
- `actionlint .github/workflows/prup-release.yml` : success
- Rust compile gate は skip しました。変更対象が `.github/actions/prup-release/run.sh` のみで、Rust build 出力に影響しないためです。
