### PR TITLE
fix: stop duplicate imago-build release runs

### DIFF
--- a/.github/workflows/imago-build.yml
+++ b/.github/workflows/imago-build.yml
@@ -7,7 +7,6 @@ on:
   release:
     types:
       - published
-      - prereleased
   workflow_dispatch:
   pull_request:
     paths:


### PR DESCRIPTION
## Motivation
- `imago-build.yml` was subscribed to both `release.published` and `release.prereleased` while `prup` currently creates GitHub Releases as prereleases.
- On `imago-v0.2.0`, that caused the same release creation flow to enqueue two `release` runs for `imago-build.yml`, duplicating the asset build/upload path.

## Summary
- Limit `imago-build.yml` release triggers to `published` only.
- Keep the existing `push(main)`, `workflow_dispatch`, and `pull_request` triggers unchanged.
- Keep the existing tag-prefix filters, artifact naming, upload flow, and `prup` prerelease policy unchanged.

## Validation
- Rust preflight skipped: changed file is `.github/workflows/imago-build.yml` only, so this branch is non-Rust-impacting under `imago-pr-preflight`.
- `cargo run --locked -p prup -- release-targets --format json`
  - Success; output still reports `"prerelease": true` for the current release targets, so the fix remains aligned with the existing release creation policy.
- `git diff --check origin/main...HEAD`
  - Success.
- `actionlint .github/workflows/imago-build.yml`
  - Not fully clean in this repo snapshot because `imago-cross-runner-set` is a custom self-hosted runner label and no local `actionlint` label config is present.
