### PR TITLE
fix: skip OCI dependency package validation

### DIFF
--- a/crates/imago-cli/src/commands/shared/dependency/cache_refresh.rs
+++ b/crates/imago-cli/src/commands/shared/dependency/cache_refresh.rs
@@ -44,10 +44,9 @@ pub(crate) async fn load_or_refresh_cache_entry(
         )
     })?;
 
-    let expected_package = if dependency.wit.source_kind == plugin_sources::SourceKind::Path {
-        None
-    } else {
-        Some(dependency.name.as_str())
+    let expected_package = match dependency.wit.source_kind {
+        plugin_sources::SourceKind::Wit => Some(dependency.name.as_str()),
+        plugin_sources::SourceKind::Oci | plugin_sources::SourceKind::Path => None,
     };
     let materialized = plugin_sources::materialize_wit_source(
         project_root,

--- a/crates/imago-cli/src/commands/update/mod.rs
+++ b/crates/imago-cli/src/commands/update/mod.rs
@@ -2469,6 +2469,7 @@ mod tests {
         let lock: ImagoLock = toml::from_str(&lock_raw).expect("lock should parse");
         let (requested, resolved) = single_dependency_entry(&lock);
         assert_eq!(requested.source, "ghcr.io/yieldspace/nanokvm".to_string());
+        assert_eq!(resolved.resolved_name, "yieldspace:nanokvm".to_string());
         assert_eq!(resolved.wit_path, "wit/deps/yieldspace-nanokvm-1.2.3");
         assert!(root.join(&resolved.wit_path).exists());
 
@@ -2519,7 +2520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_rejects_oci_dependency_when_resolved_package_mismatches_dependency_name() {
+    async fn update_accepts_oci_dependency_when_resolved_package_mismatches_dependency_name() {
         let root = new_temp_dir("oci-dependency-name-mismatch");
         write(
             &root.join("imago.toml"),
@@ -2543,20 +2544,18 @@ mod tests {
         );
 
         let result = run_with_project_root(UpdateArgs {}, &root).await;
-        assert_eq!(result.exit_code, 2);
-        let stderr = result.stderr.unwrap_or_default();
-        assert!(
-            stderr.contains("top-level WIT package mismatch"),
-            "unexpected stderr: {stderr}"
+        assert_eq!(
+            result.exit_code, 0,
+            "update should succeed: {:?}",
+            result.stderr
         );
-        assert!(
-            stderr.contains("yieldspace:nanokvm"),
-            "unexpected stderr: {stderr}"
-        );
-        assert!(
-            stderr.contains("yieldspace:other"),
-            "unexpected stderr: {stderr}"
-        );
+        let lock_raw = fs::read_to_string(root.join("imago.lock")).expect("lock should exist");
+        let lock: ImagoLock = toml::from_str(&lock_raw).expect("lock should parse");
+        let (requested, resolved) = single_dependency_entry(&lock);
+        assert_eq!(requested.source, "ghcr.io/yieldspace/nanokvm".to_string());
+        assert_eq!(resolved.resolved_name, "yieldspace:other".to_string());
+        assert_eq!(resolved.wit_path, "wit/deps/yieldspace-other-1.2.3");
+        assert!(root.join(&resolved.wit_path).exists());
 
         let _ = fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Motivation
- `imago deps sync` currently rejects OCI-backed WIT dependencies when the published top-level package name differs from the OCI source-derived package name.
- OCI packages can still be resolved safely because downstream lock/manfiest hydration already uses the resolved top-level package name, so this mismatch should not block sync.

## Summary
- Skip top-level WIT package-name equality validation for `SourceKind::Oci` dependencies during dependency cache refresh, while keeping `SourceKind::Wit` strict.
- Preserve downstream resolved-name behavior so OCI dependencies continue to record the actual top-level package name in `imago.lock` and `wit/deps` paths.
- Update `imago-cli` update tests to accept OCI package-name mismatches, assert the resolved package identity/path, and keep the Warg mismatch rejection coverage unchanged.

## Validation
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all` ✅
