### PR TITLE
ci(release): imago-cli 0.2.0 -> 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "imago-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/imago-cli/Cargo.toml
+++ b/crates/imago-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = true


### PR DESCRIPTION
## Release
- Line: `imago-cli`
- Top crate: `imago-cli`
- Bump: `minor`
- Version: `0.2.0` -> `0.3.0`
- Tag: `imago-v0.2.0` -> `imago-v0.3.0`

## Triggered By
- `imago-cli`

## Updated Crates
- `imago-cli`: `0.2.0` -> `0.3.0`

