### PR TITLE
ci: Skip PR body lint for ci(release) PRs

### DIFF
--- a/.github/workflows/ci-pr-body-checks.yml
+++ b/.github/workflows/ci-pr-body-checks.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           has_release_label="${{ contains(github.event.pull_request.labels.*.name, 'release') }}"
           has_release_title="${{ startsWith(github.event.pull_request.title, 'ci(release):') }}"
-          is_trusted_release_branch="${{ !github.event.pull_request.isCrossRepository && startsWith(github.event.pull_request.head.ref, 'codex/prup-release-') }}"
+          is_trusted_release_branch="${{ github.event.pull_request.head.repo.fork == false && startsWith(github.event.pull_request.head.ref, 'codex/prup-release-') }}"
 
           if [[ "$has_release_label" == "true" || ( "$has_release_title" == "true" && "$is_trusted_release_branch" == "true" ) ]]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Motivation
- `pr body lint` はこれまで `release` ラベル付き PR だけを exempt にしていました。
- release PR のタイトルは `ci(release): ...` で生成されるため、PR 作成直後の `opened` でラベルがまだ反映されていないと lint が誤って走ります。
- ただし title prefix だけで exempt にすると通常 PR からも lint を回避できるため、release PR の真正性を別シグナルで絞る必要があります。

## Summary
- `.github/workflows/ci-pr-body-checks.yml` に `classify_release` job を追加し、`release` ラベルまたは trusted な release PR シグナルを release PR として判定するようにしました。
- title-based exemption は `ci(release):` タイトルに加えて、fork ではない `codex/prup-release-*` branch に限定しました。
- `pr_body_lint`、`allow_release`、`checks` が同じ判定結果を使うように統一し、`checks` では `classify_release` 自体の失敗も fail-closed で落とします。

## Validation
- `git diff --name-status origin/main...HEAD` (`M .github/workflows/ci-pr-body-checks.yml`)
- `git diff --stat origin/main...HEAD` (`1 file changed, 40 insertions(+), 9 deletions(-)`)
- `git log --oneline origin/main..HEAD` (`607cc84 codex: address PR review feedback (#310)`, `db76b5a codex: address PR review feedback (#310)`, `81f5e84 ci: Skip PR body lint for ci(release) PRs`)
- `actionlint .github/workflows/ci-pr-body-checks.yml` (success)
- `git diff --check` (success)
- Rust checks skipped because the change only touches `.github/workflows/ci-pr-body-checks.yml`, which is non-Rust-impacting.
