### PR TITLE
ci(release): imagod 0.2.0 -> 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "imago"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-admin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-experimental-gpio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-experimental-i2c"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "embedded-hal",
  "imago-plugin-macros",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-protocol",
  "imagod-ipc",
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-usb"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-macros"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "imago-project-config"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "schemars 1.2.1",
@@ -2474,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "imago-protocol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ciborium",
  "serde",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "imago-schema-gen"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "imago-project-config",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "imagod"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-protocol",
  "thiserror 2.0.18",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-config"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-protocol",
  "imagod-common",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-control"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-ipc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-bootstrap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "imago-protocol",
  "imagod-common",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-control"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "imago-protocol",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-ingress"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-internal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-wasmtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3086,18 +3086,18 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-imagod-app"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "local-imagod-http-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "local-imagod-plugin-hello-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-admin-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-experimental-gpio-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-experimental-i2c-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-socket-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "tokio",
 ]
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "prup"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 publish = false
@@ -106,28 +106,28 @@ web-transport-quinn = "0.11.6"
 syn = "2.0.117"
 toml_edit = "0.23.7"
 
-imago-plugin-imago-admin = { path = "plugins/imago-admin", version = "0.2.0" }
-imago-plugin-imago-experimental-gpio = { path = "plugins/imago-experimental-gpio", version = "0.2.0" }
-imago-plugin-imago-experimental-i2c = { path = "plugins/imago-experimental-i2c", version = "0.2.0" }
-imago-plugin-imago-node = { path = "plugins/imago-node", version = "0.2.0" }
-imago-plugin-imago-usb = { path = "plugins/imago-usb", version = "0.2.0" }
+imago-plugin-imago-admin = { path = "plugins/imago-admin", version = "0.3.0" }
+imago-plugin-imago-experimental-gpio = { path = "plugins/imago-experimental-gpio", version = "0.3.0" }
+imago-plugin-imago-experimental-i2c = { path = "plugins/imago-experimental-i2c", version = "0.3.0" }
+imago-plugin-imago-node = { path = "plugins/imago-node", version = "0.3.0" }
+imago-plugin-imago-usb = { path = "plugins/imago-usb", version = "0.3.0" }
 imago-plugin-nanokvm-plugin = { path = "plugins/imago-plugin-nanokvm-plugin", version = "0.1.0" }
-imago-plugin-macros = { path = "crates/imago-plugin-macros", version = "0.2.0" }
-imago-project-config = { path = "crates/imago-project-config", version = "0.2.0" }
-imago-protocol = { path = "crates/imago-protocol", version = "0.2.0" }
-imago-schema-gen = { path = "crates/imago-schema-gen", version = "0.2.0" }
-imagod = { path = "crates/imagod", version = "0.2.0" }
-imagod-common = { path = "crates/imagod-common", version = "0.2.0" }
-imagod-config = { path = "crates/imagod-config", version = "0.2.0" }
-imagod-control = { path = "crates/imagod-control", version = "0.2.0" }
-imagod-ipc = { path = "crates/imagod-ipc", version = "0.2.0" }
-imagod-runtime = { path = "crates/imagod-runtime", version = "0.2.0", default-features = false }
-imagod-runtime-bootstrap = { path = "crates/imagod-runtime-bootstrap", version = "0.2.0" }
-imagod-runtime-control = { path = "crates/imagod-runtime-control", version = "0.2.0" }
-imagod-runtime-ingress = { path = "crates/imagod-runtime-ingress", version = "0.2.0" }
-imagod-runtime-internal = { path = "crates/imagod-runtime-internal", version = "0.2.0" }
-imagod-runtime-wasmtime = { path = "crates/imagod-runtime-wasmtime", version = "0.2.0" }
-imagod-server = { path = "crates/imagod-server", version = "0.2.0" }
+imago-plugin-macros = { path = "crates/imago-plugin-macros", version = "0.3.0" }
+imago-project-config = { path = "crates/imago-project-config", version = "0.3.0" }
+imago-protocol = { path = "crates/imago-protocol", version = "0.3.0" }
+imago-schema-gen = { path = "crates/imago-schema-gen", version = "0.3.0" }
+imagod = { path = "crates/imagod", version = "0.3.0" }
+imagod-common = { path = "crates/imagod-common", version = "0.3.0" }
+imagod-config = { path = "crates/imagod-config", version = "0.3.0" }
+imagod-control = { path = "crates/imagod-control", version = "0.3.0" }
+imagod-ipc = { path = "crates/imagod-ipc", version = "0.3.0" }
+imagod-runtime = { path = "crates/imagod-runtime", version = "0.3.0", default-features = false }
+imagod-runtime-bootstrap = { path = "crates/imagod-runtime-bootstrap", version = "0.3.0" }
+imagod-runtime-control = { path = "crates/imagod-runtime-control", version = "0.3.0" }
+imagod-runtime-ingress = { path = "crates/imagod-runtime-ingress", version = "0.3.0" }
+imagod-runtime-internal = { path = "crates/imagod-runtime-internal", version = "0.3.0" }
+imagod-runtime-wasmtime = { path = "crates/imagod-runtime-wasmtime", version = "0.3.0" }
+imagod-server = { path = "crates/imagod-server", version = "0.3.0" }
 
 [workspace.metadata.prup]
 base_ref = "origin/main"

--- a/crates/imago-protocol/Cargo.toml
+++ b/crates/imago-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-protocol"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-admin/Cargo.toml
+++ b/plugins/imago-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-admin"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-experimental-gpio/Cargo.toml
+++ b/plugins/imago-experimental-gpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-experimental-gpio"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-experimental-i2c/Cargo.toml
+++ b/plugins/imago-experimental-i2c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-experimental-i2c"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-node/Cargo.toml
+++ b/plugins/imago-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-node"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-usb/Cargo.toml
+++ b/plugins/imago-usb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-usb"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/schemas/imagod.schema.json
+++ b/schemas/imagod.schema.json
@@ -271,7 +271,7 @@
       "description": "Runtime limits and process-control knobs."
     },
     "server_version": {
-      "default": "imagod/0.2.0",
+      "default": "imagod/0.3.0",
       "description": "Server version reported via negotiate response.",
       "type": "string"
     },


### PR DESCRIPTION
## Release
- Line: `imagod-daemon`
- Top crate: `imagod`
- Bump: `minor`
- Version: `0.2.0` -> `0.3.0`
- Tag: `imagod-v0.2.0` -> `imagod-v0.3.0`

## Triggered By
- `imagod`
- `imagod-config`
- `imagod-control`
- `imagod-server`

## Updated Crates
- `imago-plugin-imago-admin`: `0.2.0` -> `0.3.0`
- `imago-plugin-imago-experimental-gpio`: `0.2.0` -> `0.3.0`
- `imago-plugin-imago-experimental-i2c`: `0.2.0` -> `0.3.0`
- `imago-plugin-imago-node`: `0.2.0` -> `0.3.0`
- `imago-plugin-imago-usb`: `0.2.0` -> `0.3.0`
- `imago-plugin-macros`: `0.2.0` -> `0.3.0`
- `imago-protocol`: `0.2.0` -> `0.3.0`
- `imagod`: `0.2.0` -> `0.3.0`
- `imagod-common`: `0.2.0` -> `0.3.0`
- `imagod-config`: `0.2.0` -> `0.3.0`
- `imagod-control`: `0.2.0` -> `0.3.0`
- `imagod-ipc`: `0.2.0` -> `0.3.0`
- `imagod-runtime`: `0.2.0` -> `0.3.0`
- `imagod-runtime-bootstrap`: `0.2.0` -> `0.3.0`
- `imagod-runtime-control`: `0.2.0` -> `0.3.0`
- `imagod-runtime-ingress`: `0.2.0` -> `0.3.0`
- `imagod-runtime-internal`: `0.2.0` -> `0.3.0`
- `imagod-runtime-wasmtime`: `0.2.0` -> `0.3.0`
- `imagod-server`: `0.2.0` -> `0.3.0`

