### PR TITLE
fix: promote releases after artifact upload

### DIFF
--- a/.github/workflows/imago-build.yml
+++ b/.github/workflows/imago-build.yml
@@ -232,3 +232,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+
+      - name: Promote GitHub Release to stable latest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          release_id="$(gh release view "${{ github.event.release.tag_name }}" --json databaseId --jq '.databaseId')"
+          if [ -z "${release_id}" ] || [ "${release_id}" = "null" ]; then
+            echo "error: failed to resolve release id for ${{ github.event.release.tag_name }}" >&2
+            exit 1
+          fi
+          gh api -X PATCH "repos/{owner}/{repo}/releases/${release_id}" \
+            -F prerelease=false \
+            -f make_latest=true


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- `prup-release` creates GitHub Releases as prereleases first, but `.github/workflows/imago-build.yml` only uploaded assets and left the release metadata unchanged.
- This kept release entries from being promoted to stable/latest even after all assets were uploaded successfully.

## Summary
- Add a post-upload promotion step to `.github/workflows/imago-build.yml` in `upload-release-assets`.
- Resolve the release database ID with `gh release view <tag> --json databaseId` and PATCH the same release to `prerelease=false` and `make_latest=true` only after asset upload succeeds.
- Keep the existing two-phase release flow intact: `prup-release` still creates prereleases first, and this workflow now promotes both `imago-v*` and `imagod-v*` releases after assets are present.

## Validation
- `actionlint .github/workflows/imago-build.yml`
  - Passed.
- Rust preflight (`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`) was skipped because the branch only changes `.github/workflows/imago-build.yml`, which is non-Rust-impacting under the skill gate.
