### PR TITLE
fix: Constrain experimental GPIO value_path to sysfs value files

### DIFF
--- a/docs/imago-configuration.md
+++ b/docs/imago-configuration.md
@@ -535,7 +535,7 @@ bulk_ring_chunk_bytes = 16384
 bulk_ring_slots = 16
 ```
 
-- Validation error notes: empty keys fail validation. `resources.gpio.digital_pins` rejects duplicated `label` and duplicated `value_path`; `resources.usb` rejects invalid path/limit settings during runtime startup.
+- Validation error notes: empty keys fail validation. `resources.gpio.digital_pins` rejects duplicated `label` and duplicated `value_path`, and requires each `value_path` to be an absolute `/sys/class/gpio/.../value` path; `resources.usb` rejects invalid path/limit settings during runtime startup.
 
 <a id="the-capabilities-section"></a>
 ## The [capabilities] section

--- a/plugins/imago-experimental-gpio/src/lib.rs
+++ b/plugins/imago-experimental-gpio/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
     path::{Path, PathBuf},
     sync::{
         Mutex, OnceLock,
@@ -120,6 +121,7 @@ const WATCH_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 const GPIO_RESOURCE_KEY: &str = "gpio";
 const GPIO_RESOURCE_DIGITAL_PINS_KEY: &str = "digital_pins";
+const GPIO_SYSFS_BASE_PATH: &str = "/sys/class/gpio";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DigitalPinSpec {
@@ -361,12 +363,30 @@ fn normalize_digital_value_path(value_path: &str) -> Result<String, GpioError> {
             _ => normalized.push(component.as_os_str()),
         }
     }
-    let normalized = normalized.to_string_lossy().into_owned();
-    if normalized.is_empty() {
+    if normalized.as_os_str().is_empty() {
         return Err(GpioError::Other(
             "resources.gpio.digital_pins[].value_path must not normalize to empty path".to_string(),
         ));
     }
+    if !normalized.is_absolute() {
+        return Err(GpioError::Other(
+            "resources.gpio.digital_pins[].value_path must be an absolute path".to_string(),
+        ));
+    }
+
+    let gpio_base_path = Path::new(GPIO_SYSFS_BASE_PATH);
+    if !normalized.starts_with(gpio_base_path) {
+        return Err(GpioError::Other(format!(
+            "resources.gpio.digital_pins[].value_path must stay under {GPIO_SYSFS_BASE_PATH}"
+        )));
+    }
+    if normalized.file_name() != Some(OsStr::new("value")) {
+        return Err(GpioError::Other(
+            "resources.gpio.digital_pins[].value_path must target a GPIO value file".to_string(),
+        ));
+    }
+
+    let normalized = normalized.to_string_lossy().into_owned();
     Ok(normalized)
 }
 
@@ -2279,6 +2299,93 @@ mod tests {
         };
         assert!(
             message.contains("value_path is duplicated"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_digital_pin_catalog_rejects_relative_value_path() {
+        let resources = BTreeMap::from([(
+            "gpio".to_string(),
+            json!({
+                "digital_pins": [
+                    {
+                        "label": "GPIO17",
+                        "value_path": "sys/class/gpio/gpio17/value",
+                        "supports_input": true,
+                        "supports_output": true,
+                        "default_active_level": "active-high",
+                        "allow_pull_resistor": true
+                    }
+                ]
+            }),
+        )]);
+        let err =
+            parse_digital_pin_catalog(&resources).expect_err("relative value_path should fail");
+        let message = match err {
+            GpioError::Other(message) => message,
+            _ => panic!("expected other error"),
+        };
+        assert!(
+            message.contains("must be an absolute path"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_digital_pin_catalog_rejects_value_path_outside_gpio_sysfs() {
+        let resources = BTreeMap::from([(
+            "gpio".to_string(),
+            json!({
+                "digital_pins": [
+                    {
+                        "label": "GPIO17",
+                        "value_path": "/etc/hosts",
+                        "supports_input": true,
+                        "supports_output": true,
+                        "default_active_level": "active-high",
+                        "allow_pull_resistor": true
+                    }
+                ]
+            }),
+        )]);
+        let err = parse_digital_pin_catalog(&resources)
+            .expect_err("value_path outside sysfs should fail");
+        let message = match err {
+            GpioError::Other(message) => message,
+            _ => panic!("expected other error"),
+        };
+        assert!(
+            message.contains("must stay under /sys/class/gpio"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_digital_pin_catalog_rejects_non_value_gpio_file() {
+        let resources = BTreeMap::from([(
+            "gpio".to_string(),
+            json!({
+                "digital_pins": [
+                    {
+                        "label": "GPIO17",
+                        "value_path": "/sys/class/gpio/gpio17/direction",
+                        "supports_input": true,
+                        "supports_output": true,
+                        "default_active_level": "active-high",
+                        "allow_pull_resistor": true
+                    }
+                ]
+            }),
+        )]);
+        let err =
+            parse_digital_pin_catalog(&resources).expect_err("non-value file path should fail");
+        let message = match err {
+            GpioError::Other(message) => message,
+            _ => panic!("expected other error"),
+        };
+        assert!(
+            message.contains("must target a GPIO value file"),
             "unexpected error: {message}"
         );
     }


### PR DESCRIPTION
## Motivation
- Prevent untrusted service manifests from pointing `resources.gpio.digital_pins[].value_path` at arbitrary host files and thereby enabling host file read/write via the experimental GPIO native plugin.

## Summary
- Hardened path validation in `plugins/imago-experimental-gpio/src/lib.rs` by requiring `value_path` to be non-empty after normalization, absolute, located under `/sys/class/gpio`, and target the `value` filename. 
- Introduced `GPIO_SYSFS_BASE_PATH` and added `OsStr` usage to validate the final path component is `value`.
- Added regression unit tests that reject relative paths, paths outside GPIO sysfs (e.g. `/etc/hosts`), and non-`value` GPIO files (e.g. `direction`).
- Updated `docs/imago-configuration.md` to document the stricter `value_path` contract (`/sys/class/gpio/.../value`).

## Validation
- Ran formatter: `cargo fmt --all` and applied formatting changes successfully.
- Ran targeted unit tests: `cargo test -p imago-plugin-imago-experimental-gpio parse_digital_pin_catalog -- --nocapture` and observed the test binary run with the added/related tests; result: 13 passed, 0 failed.
- Verified the new parsing tests cover the regression cases for relative paths, non-sysfs paths, and non-`value` GPIO files and that existing catalog validation tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc2151d808333907e1fde9469c972)