### PR TITLE
ci(release): imagod 0.3.0 -> 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "imago"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -2405,7 +2405,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-admin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-experimental-gpio"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-experimental-i2c"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "embedded-hal",
  "imago-plugin-macros",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-protocol",
  "imagod-ipc",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-imago-usb"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-plugin-macros",
  "imagod-runtime-wasmtime",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "imago-plugin-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "imago-project-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "schemars 1.2.1",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "imago-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ciborium",
  "serde",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "imago-schema-gen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "imago-project-config",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "imagod"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-protocol",
  "thiserror 2.0.18",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-protocol",
  "imagod-common",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-control"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "criterion",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-ipc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-bootstrap"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "imago-protocol",
  "imagod-common",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-control"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "imago-protocol",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-ingress"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-internal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-runtime-wasmtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "imagod-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3131,18 +3131,18 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-imagod-app"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "local-imagod-http-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "local-imagod-plugin-hello-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-admin-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-experimental-gpio-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-plugin-native-experimental-i2c-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wasi 0.14.7+wasi-0.2.4",
  "wit-bindgen 0.53.1",
@@ -3174,14 +3174,14 @@ dependencies = [
 
 [[package]]
 name = "local-imagod-socket-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "local-imagod-wasi-nn-openvino-person-detection-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "wit-bindgen 0.53.1",
 ]
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "prup"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 publish = false
@@ -107,27 +107,27 @@ web-transport-quinn = "0.11.6"
 syn = "2.0.117"
 toml_edit = "0.23.7"
 
-imago-plugin-imago-admin = { path = "plugins/imago-admin", version = "0.3.0" }
-imago-plugin-imago-experimental-gpio = { path = "plugins/imago-experimental-gpio", version = "0.3.0" }
-imago-plugin-imago-experimental-i2c = { path = "plugins/imago-experimental-i2c", version = "0.3.0" }
-imago-plugin-imago-node = { path = "plugins/imago-node", version = "0.3.0" }
-imago-plugin-imago-usb = { path = "plugins/imago-usb", version = "0.3.0" }
-imago-plugin-macros = { path = "crates/imago-plugin-macros", version = "0.3.0" }
-imago-project-config = { path = "crates/imago-project-config", version = "0.3.0" }
-imago-protocol = { path = "crates/imago-protocol", version = "0.3.0" }
-imago-schema-gen = { path = "crates/imago-schema-gen", version = "0.3.0" }
-imagod = { path = "crates/imagod", version = "0.3.0" }
-imagod-common = { path = "crates/imagod-common", version = "0.3.0" }
-imagod-config = { path = "crates/imagod-config", version = "0.3.0" }
-imagod-control = { path = "crates/imagod-control", version = "0.3.0" }
-imagod-ipc = { path = "crates/imagod-ipc", version = "0.3.0" }
-imagod-runtime = { path = "crates/imagod-runtime", version = "0.3.0", default-features = false }
-imagod-runtime-bootstrap = { path = "crates/imagod-runtime-bootstrap", version = "0.3.0" }
-imagod-runtime-control = { path = "crates/imagod-runtime-control", version = "0.3.0" }
-imagod-runtime-ingress = { path = "crates/imagod-runtime-ingress", version = "0.3.0" }
-imagod-runtime-internal = { path = "crates/imagod-runtime-internal", version = "0.3.0" }
-imagod-runtime-wasmtime = { path = "crates/imagod-runtime-wasmtime", version = "0.3.0" }
-imagod-server = { path = "crates/imagod-server", version = "0.3.0" }
+imago-plugin-imago-admin = { path = "plugins/imago-admin", version = "0.3.1" }
+imago-plugin-imago-experimental-gpio = { path = "plugins/imago-experimental-gpio", version = "0.3.1" }
+imago-plugin-imago-experimental-i2c = { path = "plugins/imago-experimental-i2c", version = "0.3.1" }
+imago-plugin-imago-node = { path = "plugins/imago-node", version = "0.3.1" }
+imago-plugin-imago-usb = { path = "plugins/imago-usb", version = "0.3.1" }
+imago-plugin-macros = { path = "crates/imago-plugin-macros", version = "0.3.1" }
+imago-project-config = { path = "crates/imago-project-config", version = "0.3.1" }
+imago-protocol = { path = "crates/imago-protocol", version = "0.3.1" }
+imago-schema-gen = { path = "crates/imago-schema-gen", version = "0.3.1" }
+imagod = { path = "crates/imagod", version = "0.3.1" }
+imagod-common = { path = "crates/imagod-common", version = "0.3.1" }
+imagod-config = { path = "crates/imagod-config", version = "0.3.1" }
+imagod-control = { path = "crates/imagod-control", version = "0.3.1" }
+imagod-ipc = { path = "crates/imagod-ipc", version = "0.3.1" }
+imagod-runtime = { path = "crates/imagod-runtime", version = "0.3.1", default-features = false }
+imagod-runtime-bootstrap = { path = "crates/imagod-runtime-bootstrap", version = "0.3.1" }
+imagod-runtime-control = { path = "crates/imagod-runtime-control", version = "0.3.1" }
+imagod-runtime-ingress = { path = "crates/imagod-runtime-ingress", version = "0.3.1" }
+imagod-runtime-internal = { path = "crates/imagod-runtime-internal", version = "0.3.1" }
+imagod-runtime-wasmtime = { path = "crates/imagod-runtime-wasmtime", version = "0.3.1" }
+imagod-server = { path = "crates/imagod-server", version = "0.3.1" }
 
 [workspace.metadata.prup]
 base_ref = "origin/main"

--- a/crates/imago-protocol/Cargo.toml
+++ b/crates/imago-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-protocol"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-admin/Cargo.toml
+++ b/plugins/imago-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-admin"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-experimental-gpio/Cargo.toml
+++ b/plugins/imago-experimental-gpio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-experimental-gpio"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-experimental-i2c/Cargo.toml
+++ b/plugins/imago-experimental-i2c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-experimental-i2c"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-node/Cargo.toml
+++ b/plugins/imago-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-node"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/plugins/imago-usb/Cargo.toml
+++ b/plugins/imago-usb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imago-plugin-imago-usb"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/schemas/imagod.schema.json
+++ b/schemas/imagod.schema.json
@@ -296,7 +296,7 @@
       "description": "Runtime limits and process-control knobs."
     },
     "server_version": {
-      "default": "imagod/0.3.0",
+      "default": "imagod/0.3.1",
       "description": "Server version reported via negotiate response.",
       "type": "string"
     },


### PR DESCRIPTION
## Release
- Line: `imagod-daemon`
- Top crate: `imagod`
- Bump: `patch`
- Version: `0.3.0` -> `0.3.1`
- Tag: `imagod-v0.3.0` -> `imagod-v0.3.1`

## Triggered By
- `imago-plugin-imago-admin`
- `imago-plugin-imago-experimental-gpio`
- `imago-plugin-imago-experimental-i2c`
- `imago-plugin-imago-node`
- `imago-plugin-imago-usb`
- `imagod`
- `imagod-common`
- `imagod-config`
- `imagod-control`
- `imagod-ipc`
- `imagod-runtime`
- `imagod-runtime-bootstrap`
- `imagod-runtime-control`
- `imagod-runtime-ingress`
- `imagod-runtime-internal`
- `imagod-runtime-wasmtime`
- `imagod-server`

## Updated Crates
- `imago-plugin-imago-admin`: `0.3.0` -> `0.3.1`
- `imago-plugin-imago-experimental-gpio`: `0.3.0` -> `0.3.1`
- `imago-plugin-imago-experimental-i2c`: `0.3.0` -> `0.3.1`
- `imago-plugin-imago-node`: `0.3.0` -> `0.3.1`
- `imago-plugin-imago-usb`: `0.3.0` -> `0.3.1`
- `imago-plugin-macros`: `0.3.0` -> `0.3.1`
- `imago-protocol`: `0.3.0` -> `0.3.1`
- `imagod`: `0.3.0` -> `0.3.1`
- `imagod-common`: `0.3.0` -> `0.3.1`
- `imagod-config`: `0.3.0` -> `0.3.1`
- `imagod-control`: `0.3.0` -> `0.3.1`
- `imagod-ipc`: `0.3.0` -> `0.3.1`
- `imagod-runtime`: `0.3.0` -> `0.3.1`
- `imagod-runtime-bootstrap`: `0.3.0` -> `0.3.1`
- `imagod-runtime-control`: `0.3.0` -> `0.3.1`
- `imagod-runtime-ingress`: `0.3.0` -> `0.3.1`
- `imagod-runtime-internal`: `0.3.0` -> `0.3.1`
- `imagod-runtime-wasmtime`: `0.3.0` -> `0.3.1`
- `imagod-server`: `0.3.0` -> `0.3.1`

