### PR TITLE
ci: Reduce non-release artifact retention to 1 day

### DIFF
--- a/.github/workflows/imago-build.yml
+++ b/.github/workflows/imago-build.yml
@@ -201,7 +201,7 @@ jobs:
           if-no-files-found: error
           name: ${{ matrix.target }}-binaries-${{ github.sha }}
           path: dist/*
-          retention-days: 7
+          retention-days: 1
 
       - name: Show sccache stats
         if: always()


### PR DESCRIPTION
## Motivation
- Non-release `imago-build` artifacts currently keep CI binaries for 7 days across `push`, `pull_request`, and `workflow_dispatch` runs.
- These artifacts are only needed short-term, so reducing retention to 1 day lowers artifact storage overhead without affecting release assets.

## Summary
- Update `.github/workflows/imago-build.yml` so `Upload CI artifacts` uses `retention-days: 1` for non-release runs.
- Keep `Upload release artifacts` at `retention-days: 7`.
- No Rust/API/protocol/schema/WIT or user-facing docs changes.

## Validation
- `actionlint .github/workflows/imago-build.yml`
  - Passed.
- `git diff -- .github/workflows/imago-build.yml`
  - Confirmed the only change is the non-release artifact retention from 7 days to 1 day.
- Rust preflight checks skipped because the only changed file is `.github/workflows/imago-build.yml`, which is non-Rust-impacting under the preflight gate.
