### PR TITLE
feat: add runtime feature filters for builtin plugins

### DIFF
--- a/crates/imago-schema-gen/src/lib.rs
+++ b/crates/imago-schema-gen/src/lib.rs
@@ -105,6 +105,8 @@ mod tests {
 
         let imago_json: JsonValue =
             serde_json::from_str(&first_imago).expect("imago schema should parse as json");
+        let imagod_json: JsonValue =
+            serde_json::from_str(&first_imagod).expect("imagod schema should parse as json");
         let props = imago_json
             .get("properties")
             .and_then(JsonValue::as_object)
@@ -148,6 +150,27 @@ mod tests {
             .and_then(|entry| entry.get("required"))
             .and_then(JsonValue::as_array)
             .expect("BindingEntry.required should be array");
+        let imagod_defs = imagod_json
+            .get("$defs")
+            .and_then(JsonValue::as_object)
+            .expect("imagod $defs should be object");
+        let imagod_runtime_props = imagod_defs
+            .get("RuntimeConfig")
+            .and_then(|entry| entry.get("properties"))
+            .and_then(JsonValue::as_object)
+            .expect("imagod RuntimeConfig.properties should be object");
+        let features_any_of = imagod_runtime_props
+            .get("features")
+            .and_then(|entry| entry.get("anyOf"))
+            .and_then(JsonValue::as_array)
+            .expect("imagod RuntimeConfig.features.anyOf should be array");
+        let feature_items_enum = features_any_of
+            .iter()
+            .find(|entry| entry.get("type").and_then(JsonValue::as_str) == Some("array"))
+            .and_then(|entry| entry.get("items"))
+            .and_then(|entry| entry.get("enum"))
+            .and_then(JsonValue::as_array)
+            .expect("imagod RuntimeConfig.features array schema should enumerate package names");
 
         assert!(
             !props.contains_key("capabilirties"),
@@ -214,6 +237,30 @@ mod tests {
         assert!(
             !defs.contains_key("LegacyRuntimeSection"),
             "legacy runtime section type must not be exposed in schema definitions"
+        );
+        assert!(
+            features_any_of
+                .iter()
+                .any(|entry| entry.get("type").and_then(JsonValue::as_str) == Some("boolean")),
+            "imagod RuntimeConfig.features should accept booleans"
+        );
+        assert!(
+            feature_items_enum
+                .iter()
+                .any(|value| value.as_str() == Some("imago:admin")),
+            "imagod RuntimeConfig.features should enumerate imago:admin"
+        );
+        assert!(
+            feature_items_enum
+                .iter()
+                .any(|value| value.as_str() == Some("imago:node")),
+            "imagod RuntimeConfig.features should enumerate imago:node"
+        );
+        assert!(
+            feature_items_enum
+                .iter()
+                .any(|value| value.as_str() == Some("imago:usb")),
+            "imagod RuntimeConfig.features should enumerate imago:usb"
         );
     }
 }

--- a/crates/imagod-common/src/builtin_native_plugins.rs
+++ b/crates/imagod-common/src/builtin_native_plugins.rs
@@ -1,0 +1,39 @@
+/// Built-in native plugin metadata shared by config loading and runner startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinNativePluginDescriptor {
+    /// Canonical package name used in manifests and runtime registries.
+    pub package_name: &'static str,
+    /// Whether the plugin is enabled when `[runtime].features` is unset/false/empty.
+    pub default_enabled: bool,
+}
+
+/// Canonical descriptor table for all built-in native plugins linked into `imagod`.
+pub const BUILTIN_NATIVE_PLUGIN_DESCRIPTORS: [BuiltinNativePluginDescriptor; 5] = [
+    BuiltinNativePluginDescriptor {
+        package_name: "imago:admin",
+        default_enabled: true,
+    },
+    BuiltinNativePluginDescriptor {
+        package_name: "imago:node",
+        default_enabled: true,
+    },
+    BuiltinNativePluginDescriptor {
+        package_name: "imago:experimental-gpio",
+        default_enabled: false,
+    },
+    BuiltinNativePluginDescriptor {
+        package_name: "imago:experimental-i2c",
+        default_enabled: false,
+    },
+    BuiltinNativePluginDescriptor {
+        package_name: "imago:usb",
+        default_enabled: false,
+    },
+];
+
+/// Returns true when `package_name` matches one of the built-in native plugins.
+pub fn is_builtin_native_plugin_package_name(package_name: &str) -> bool {
+    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+        .iter()
+        .any(|descriptor| descriptor.package_name == package_name)
+}

--- a/crates/imagod-common/src/lib.rs
+++ b/crates/imagod-common/src/lib.rs
@@ -6,6 +6,12 @@ use imago_protocol::{ErrorCode, StructuredError};
 use thiserror::Error;
 
 mod builders;
+mod builtin_native_plugins;
+
+pub use builtin_native_plugins::{
+    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS, BuiltinNativePluginDescriptor,
+    is_builtin_native_plugin_package_name,
+};
 
 /// Default Wasmtime linear-memory reservation size in bytes.
 pub const DEFAULT_WASM_MEMORY_RESERVATION_BYTES: u64 = 64 * 1024 * 1024;

--- a/crates/imagod-config/src/lib.rs
+++ b/crates/imagod-config/src/lib.rs
@@ -4,7 +4,9 @@
 //! validation used before network/session runtime components are initialized.
 
 use std::{
+    borrow::Cow,
     collections::BTreeMap,
+    collections::BTreeSet,
     fs,
     io::{ErrorKind, Write},
     path::{Path, PathBuf},
@@ -17,9 +19,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use imagod_common::{
-    DEFAULT_WASM_GUARD_BEFORE_LINEAR_MEMORY, DEFAULT_WASM_MEMORY_GUARD_SIZE_BYTES,
-    DEFAULT_WASM_MEMORY_RESERVATION_BYTES, DEFAULT_WASM_MEMORY_RESERVATION_FOR_GROWTH_BYTES,
-    DEFAULT_WASM_PARALLEL_COMPILATION, ImagodError,
+    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS, DEFAULT_WASM_GUARD_BEFORE_LINEAR_MEMORY,
+    DEFAULT_WASM_MEMORY_GUARD_SIZE_BYTES, DEFAULT_WASM_MEMORY_RESERVATION_BYTES,
+    DEFAULT_WASM_MEMORY_RESERVATION_FOR_GROWTH_BYTES, DEFAULT_WASM_PARALLEL_COMPILATION,
+    ImagodError,
 };
 
 mod load;
@@ -75,6 +78,84 @@ pub struct TlsConfig {
     #[serde(default)]
     /// TOFU-known remote authorities mapped to Ed25519 raw public key hex.
     pub known_public_keys: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+/// Built-in native plugin loading policy configured via `[runtime].features`.
+pub enum RuntimeFeatures {
+    /// `true` enables all built-in plugins; `false` keeps only the default set.
+    Enabled(bool),
+    /// Additional built-in package names enabled beyond the default set.
+    Packages(Vec<String>),
+}
+
+impl Default for RuntimeFeatures {
+    fn default() -> Self {
+        Self::Enabled(false)
+    }
+}
+
+impl RuntimeFeatures {
+    /// Returns the effective built-in native plugin allowlist in canonical package order.
+    pub fn effective_builtin_native_plugin_package_names(&self) -> Vec<String> {
+        let requested = match self {
+            Self::Enabled(true) => None,
+            Self::Enabled(false) => Some(BTreeSet::new()),
+            Self::Packages(package_names) => Some(
+                package_names
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<BTreeSet<_>>(),
+            ),
+        };
+
+        BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+            .iter()
+            .filter(|descriptor| {
+                descriptor.default_enabled
+                    || requested.is_none()
+                    || requested
+                        .as_ref()
+                        .is_some_and(|requested| requested.contains(descriptor.package_name))
+            })
+            .map(|descriptor| descriptor.package_name.to_string())
+            .collect()
+    }
+}
+
+impl JsonSchema for RuntimeFeatures {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "RuntimeFeatures".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let allowed_packages = BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+            .iter()
+            .map(|descriptor| descriptor.package_name.to_string())
+            .collect::<Vec<_>>();
+
+        schemars::json_schema!({
+            "anyOf": [
+                {
+                    "type": "boolean",
+                    "description": "true enables all built-in native plugins; false keeps only the default set"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": allowed_packages
+                    },
+                    "description": "Additional built-in native plugin package names enabled beyond the default set"
+                }
+            ]
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -158,6 +239,9 @@ pub struct RuntimeConfig {
     #[serde(default = "default_boot_restore_enabled")]
     /// Whether restart-policy boot restore runs at manager boot.
     pub boot_restore_enabled: bool,
+    #[serde(default)]
+    /// Built-in native plugin loading policy for runner startup.
+    pub features: RuntimeFeatures,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -207,7 +291,16 @@ impl Default for RuntimeConfig {
             transport_max_idle_timeout_secs: default_transport_max_idle_timeout_secs(),
             boot_plugin_gc_enabled: default_boot_plugin_gc_enabled(),
             boot_restore_enabled: default_boot_restore_enabled(),
+            features: RuntimeFeatures::default(),
         }
+    }
+}
+
+impl RuntimeConfig {
+    /// Returns the canonical built-in native plugin allowlist for runner startup.
+    pub fn effective_builtin_native_plugin_package_names(&self) -> Vec<String> {
+        self.features
+            .effective_builtin_native_plugin_package_names()
     }
 }
 
@@ -977,6 +1070,12 @@ client_public_keys = ["111111111111111111111111111111111111111111111111111111111
         assert_eq!(config.runtime.transport_max_idle_timeout_secs, 180);
         assert!(config.runtime.boot_plugin_gc_enabled);
         assert!(config.runtime.boot_restore_enabled);
+        assert_eq!(
+            config
+                .runtime
+                .effective_builtin_native_plugin_package_names(),
+            vec!["imago:admin".to_string(), "imago:node".to_string()]
+        );
 
         cleanup_temp_path(path);
     }
@@ -1048,6 +1147,154 @@ boot_restore_enabled = false
         let config = ImagodConfig::load(&path).expect("config should load");
         assert!(!config.runtime.boot_plugin_gc_enabled);
         assert!(!config.runtime.boot_restore_enabled);
+
+        cleanup_temp_path(path);
+    }
+
+    #[test]
+    fn runtime_features_true_enables_all_builtin_plugins() {
+        let path = write_temp_config(
+            "runtime_features_true_enables_all_builtin_plugins",
+            r#"
+listen_addr = "127.0.0.1:4443"
+storage_root = "/tmp/imago-explicit"
+server_version = "imagod/test"
+
+[tls]
+server_key = "server.key"
+client_public_keys = ["1111111111111111111111111111111111111111111111111111111111111111"]
+
+[runtime]
+features = true
+"#,
+        );
+
+        let config = ImagodConfig::load(&path).expect("config should load");
+        assert_eq!(
+            config
+                .runtime
+                .effective_builtin_native_plugin_package_names(),
+            BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+                .iter()
+                .map(|descriptor| descriptor.package_name.to_string())
+                .collect::<Vec<_>>()
+        );
+
+        cleanup_temp_path(path);
+    }
+
+    #[test]
+    fn runtime_features_false_keeps_default_builtin_plugins() {
+        let path = write_temp_config(
+            "runtime_features_false_keeps_default_builtin_plugins",
+            r#"
+listen_addr = "127.0.0.1:4443"
+storage_root = "/tmp/imago-explicit"
+server_version = "imagod/test"
+
+[tls]
+server_key = "server.key"
+client_public_keys = ["1111111111111111111111111111111111111111111111111111111111111111"]
+
+[runtime]
+features = false
+"#,
+        );
+
+        let config = ImagodConfig::load(&path).expect("config should load");
+        assert_eq!(
+            config
+                .runtime
+                .effective_builtin_native_plugin_package_names(),
+            vec!["imago:admin".to_string(), "imago:node".to_string()]
+        );
+
+        cleanup_temp_path(path);
+    }
+
+    #[test]
+    fn runtime_features_empty_array_keeps_default_builtin_plugins() {
+        let path = write_temp_config(
+            "runtime_features_empty_array_keeps_default_builtin_plugins",
+            r#"
+listen_addr = "127.0.0.1:4443"
+storage_root = "/tmp/imago-explicit"
+server_version = "imagod/test"
+
+[tls]
+server_key = "server.key"
+client_public_keys = ["1111111111111111111111111111111111111111111111111111111111111111"]
+
+[runtime]
+features = []
+"#,
+        );
+
+        let config = ImagodConfig::load(&path).expect("config should load");
+        assert_eq!(
+            config
+                .runtime
+                .effective_builtin_native_plugin_package_names(),
+            vec!["imago:admin".to_string(), "imago:node".to_string()]
+        );
+
+        cleanup_temp_path(path);
+    }
+
+    #[test]
+    fn runtime_features_array_adds_named_builtin_plugins() {
+        let path = write_temp_config(
+            "runtime_features_array_adds_named_builtin_plugins",
+            r#"
+listen_addr = "127.0.0.1:4443"
+storage_root = "/tmp/imago-explicit"
+server_version = "imagod/test"
+
+[tls]
+server_key = "server.key"
+client_public_keys = ["1111111111111111111111111111111111111111111111111111111111111111"]
+
+[runtime]
+features = ["imago:usb", "imago:admin", "imago:usb"]
+"#,
+        );
+
+        let config = ImagodConfig::load(&path).expect("config should load");
+        assert_eq!(
+            config
+                .runtime
+                .effective_builtin_native_plugin_package_names(),
+            vec![
+                "imago:admin".to_string(),
+                "imago:node".to_string(),
+                "imago:usb".to_string()
+            ]
+        );
+
+        cleanup_temp_path(path);
+    }
+
+    #[test]
+    fn runtime_features_rejects_unknown_builtin_plugin_name() {
+        let path = write_temp_config(
+            "runtime_features_rejects_unknown_builtin_plugin_name",
+            r#"
+listen_addr = "127.0.0.1:4443"
+storage_root = "/tmp/imago-explicit"
+server_version = "imagod/test"
+
+[tls]
+server_key = "server.key"
+client_public_keys = ["1111111111111111111111111111111111111111111111111111111111111111"]
+
+[runtime]
+features = ["imago:unknown"]
+"#,
+        );
+
+        let err = ImagodConfig::load(&path).expect_err("config should reject unknown builtin");
+        assert!(err.to_string().contains("runtime.features[0]"));
+        assert!(err.to_string().contains("imago:unknown"));
 
         cleanup_temp_path(path);
     }

--- a/crates/imagod-config/src/load/validation.rs
+++ b/crates/imagod-config/src/load/validation.rs
@@ -8,9 +8,10 @@ use std::path::Path;
 
 use imago_protocol::ErrorCode;
 use imagod_common::ImagodError;
+use imagod_common::{BUILTIN_NATIVE_PLUGIN_DESCRIPTORS, is_builtin_native_plugin_package_name};
 
 use crate::{
-    ImagodConfig, MAX_CHUNK_SIZE_BYTES, MAX_HTTP_QUEUE_MEMORY_BUDGET_BYTES,
+    ImagodConfig, MAX_CHUNK_SIZE_BYTES, MAX_HTTP_QUEUE_MEMORY_BUDGET_BYTES, RuntimeFeatures,
     parse_ed25519_raw_public_key_hex,
 };
 
@@ -77,6 +78,7 @@ pub(crate) fn validate(config: &ImagodConfig) -> Result<(), ImagodError> {
         parse_unique_public_key_hexes(&config.tls.client_public_keys, "tls.client_public_keys")?;
     parse_unique_public_key_hexes(&config.tls.admin_public_keys, "tls.admin_public_keys")?;
     parse_known_public_key_map(&config.tls.known_public_keys)?;
+    validate_runtime_features(&config.runtime.features)?;
 
     for (index, key_hex) in config.tls.admin_public_keys.iter().enumerate() {
         let decoded = parse_ed25519_raw_public_key_hex(key_hex).map_err(|reason| {
@@ -280,6 +282,34 @@ pub(crate) fn validate(config: &ImagodConfig) -> Result<(), ImagodError> {
             "config.load",
             "runtime.max_inflight_chunks must be greater than 0",
         ));
+    }
+
+    Ok(())
+}
+
+fn validate_runtime_features(features: &RuntimeFeatures) -> Result<(), ImagodError> {
+    let RuntimeFeatures::Packages(package_names) = features else {
+        return Ok(());
+    };
+
+    let supported = BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+        .iter()
+        .map(|descriptor| descriptor.package_name)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    for (index, package_name) in package_names.iter().enumerate() {
+        if is_builtin_native_plugin_package_name(package_name) {
+            continue;
+        }
+
+        return Err(ImagodError::new(
+            ErrorCode::BadRequest,
+            "config.load",
+            format!("runtime.features[{index}] must be one of: {supported} (got '{package_name}')"),
+        )
+        .with_detail("index", index.to_string())
+        .with_detail("value", package_name));
     }
 
     Ok(())

--- a/crates/imagod-control/src/service_supervisor.rs
+++ b/crates/imagod-control/src/service_supervisor.rs
@@ -22,9 +22,10 @@ use std::{
 
 use imago_protocol::ErrorCode;
 use imagod_common::{
-    DEFAULT_WASM_GUARD_BEFORE_LINEAR_MEMORY, DEFAULT_WASM_MEMORY_GUARD_SIZE_BYTES,
-    DEFAULT_WASM_MEMORY_RESERVATION_BYTES, DEFAULT_WASM_MEMORY_RESERVATION_FOR_GROWTH_BYTES,
-    DEFAULT_WASM_PARALLEL_COMPILATION, ImagodError,
+    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS, DEFAULT_WASM_GUARD_BEFORE_LINEAR_MEMORY,
+    DEFAULT_WASM_MEMORY_GUARD_SIZE_BYTES, DEFAULT_WASM_MEMORY_RESERVATION_BYTES,
+    DEFAULT_WASM_MEMORY_RESERVATION_FOR_GROWTH_BYTES, DEFAULT_WASM_PARALLEL_COMPILATION,
+    ImagodError,
 };
 use imagod_ipc::{
     CapabilityPolicy, PluginDependency, ResourceMap, RunnerAppType, RunnerBootstrap,
@@ -225,6 +226,7 @@ pub struct ServiceSupervisor {
     wasm_memory_guard_size_bytes: u64,
     wasm_guard_before_linear_memory: bool,
     wasm_parallel_compilation: bool,
+    enabled_native_plugins: Vec<String>,
     runner_log_buffer_bytes: usize,
     epoch_tick_interval_ms: u64,
     manager_control_endpoint: PathBuf,
@@ -366,6 +368,11 @@ impl ServiceSupervisor {
             wasm_memory_guard_size_bytes: DEFAULT_WASM_MEMORY_GUARD_SIZE_BYTES,
             wasm_guard_before_linear_memory: DEFAULT_WASM_GUARD_BEFORE_LINEAR_MEMORY,
             wasm_parallel_compilation: DEFAULT_WASM_PARALLEL_COMPILATION,
+            enabled_native_plugins: BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+                .iter()
+                .filter(|descriptor| descriptor.default_enabled)
+                .map(|descriptor| descriptor.package_name.to_string())
+                .collect(),
             runner_log_buffer_bytes,
             epoch_tick_interval_ms: epoch_tick_interval_ms.max(1),
             manager_control_endpoint,
@@ -409,6 +416,12 @@ impl ServiceSupervisor {
         self
     }
 
+    /// Overrides the effective built-in native plugin allowlist propagated to runners.
+    pub fn with_enabled_native_plugins(mut self, enabled_native_plugins: Vec<String>) -> Self {
+        self.enabled_native_plugins = enabled_native_plugins;
+        self
+    }
+
     /// Starts a service by spawning a runner child process.
     pub async fn start(&self, launch: ServiceLaunch) -> Result<(), ImagodError> {
         self.start_internal(launch, false).await
@@ -448,6 +461,7 @@ impl ServiceSupervisor {
                 resources: launch.resources.clone(),
                 bindings: launch.bindings.clone(),
                 plugin_dependencies: launch.plugin_dependencies.clone(),
+                enabled_native_plugins: self.enabled_native_plugins.clone(),
                 capabilities: launch.capabilities.clone(),
                 manager_control_endpoint: self.manager_control_endpoint.clone(),
                 runner_endpoint: runner_endpoint.clone(),

--- a/crates/imagod-ipc/src/ipc/mod.rs
+++ b/crates/imagod-ipc/src/ipc/mod.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sha2::Sha256;
 
-use imagod_common::ImagodError;
+use imagod_common::{ImagodError, is_builtin_native_plugin_package_name};
 
 /// DBus-like peer-to-peer transport implementation over Unix domain sockets.
 pub mod dbus_p2p;
@@ -690,6 +690,9 @@ pub struct RunnerBootstrap {
     /// Plugin dependencies available for this app/plugin execution context.
     #[serde(default)]
     pub plugin_dependencies: Vec<PluginDependency>,
+    /// Effective built-in native plugin allowlist propagated from manager config.
+    #[serde(default)]
+    pub enabled_native_plugins: Vec<String>,
     /// App-level capability policy.
     #[serde(default)]
     pub capabilities: CapabilityPolicy,
@@ -789,6 +792,15 @@ impl Validate for RunnerBootstrap {
         }
         for dependency in &self.plugin_dependencies {
             dependency.validate()?;
+        }
+        for package_name in &self.enabled_native_plugins {
+            validate_non_empty(package_name, "enabled_native_plugins")?;
+            if !is_builtin_native_plugin_package_name(package_name) {
+                return Err(ValidationError::invalid(
+                    "enabled_native_plugins",
+                    "must contain only built-in native plugin package names",
+                ));
+            }
         }
         self.capabilities.validate()?;
 
@@ -1378,6 +1390,7 @@ mod tests {
             resources: BTreeMap::new(),
             bindings: vec![],
             plugin_dependencies: vec![],
+            enabled_native_plugins: vec!["imago:admin".to_string(), "imago:node".to_string()],
             capabilities: CapabilityPolicy::default(),
             manager_control_endpoint: PathBuf::from("/tmp/manager.sock"),
             runner_endpoint: PathBuf::from("/tmp/runner.sock"),
@@ -1411,6 +1424,17 @@ mod tests {
         bootstrap
             .validate()
             .expect("rpc app type should be validated like cli");
+    }
+
+    #[test]
+    fn runner_bootstrap_rejects_unknown_enabled_native_plugin() {
+        let mut bootstrap = valid_http_bootstrap();
+        bootstrap.enabled_native_plugins = vec!["imago:unknown".to_string()];
+
+        let err = bootstrap
+            .validate()
+            .expect_err("unknown builtin plugin should fail bootstrap validation");
+        assert_eq!(err.field, "enabled_native_plugins");
     }
 
     #[test]
@@ -1455,6 +1479,11 @@ mod tests {
                 component: None,
                 capabilities: CapabilityPolicy::default(),
             }],
+            enabled_native_plugins: vec![
+                "imago:admin".to_string(),
+                "imago:node".to_string(),
+                "imago:usb".to_string(),
+            ],
             capabilities: CapabilityPolicy {
                 privileged: false,
                 deps: BTreeMap::from([(
@@ -1506,6 +1535,14 @@ mod tests {
         assert_eq!(
             decoded.plugin_dependencies[0].name,
             "yieldspace:plugin/example"
+        );
+        assert_eq!(
+            decoded.enabled_native_plugins,
+            vec![
+                "imago:admin".to_string(),
+                "imago:node".to_string(),
+                "imago:usb".to_string()
+            ]
         );
         assert!(
             decoded

--- a/crates/imagod-runtime-control/src/lib.rs
+++ b/crates/imagod-runtime-control/src/lib.rs
@@ -558,6 +558,7 @@ mod tests {
             resources: BTreeMap::new(),
             bindings: Vec::new(),
             plugin_dependencies: Vec::new(),
+            enabled_native_plugins: vec!["imago:admin".to_string(), "imago:node".to_string()],
             capabilities: imagod_ipc::CapabilityPolicy::default(),
             manager_control_endpoint: root.join("manager-control.sock"),
             runner_endpoint: root.join(runner_socket_name),

--- a/crates/imagod-runtime-ingress/src/lib.rs
+++ b/crates/imagod-runtime-ingress/src/lib.rs
@@ -433,6 +433,7 @@ mod tests {
             resources: BTreeMap::new(),
             bindings: Vec::new(),
             plugin_dependencies: Vec::new(),
+            enabled_native_plugins: vec!["imago:admin".to_string(), "imago:node".to_string()],
             capabilities: imagod_ipc::CapabilityPolicy::default(),
             manager_control_endpoint: root.join("manager-control.sock"),
             runner_endpoint: root.join("runner.sock"),

--- a/crates/imagod-runtime-wasmtime/src/native_plugins/registry.rs
+++ b/crates/imagod-runtime-wasmtime/src/native_plugins/registry.rs
@@ -46,6 +46,19 @@ impl NativePluginRegistry {
             .map(|plugin| plugin.supports_symbol(symbol))
             .unwrap_or(false)
     }
+
+    pub fn filtered(
+        &self,
+        mut include: impl FnMut(&str) -> bool,
+    ) -> Result<NativePluginRegistry, ImagodError> {
+        let mut builder = NativePluginRegistryBuilder::new();
+        for (package_name, plugin) in self.plugins.iter() {
+            if include(package_name) {
+                builder.register_plugin(plugin.clone())?;
+            }
+        }
+        Ok(builder.build())
+    }
 }
 
 #[derive(Default)]
@@ -176,5 +189,21 @@ mod tests {
             !registry.has_symbol("test:plugin", "test:plugin/runtime@0.1.0.unknown"),
             "unexpected symbol should be rejected"
         );
+    }
+
+    #[test]
+    fn filtered_registry_keeps_only_matching_packages() {
+        let mut builder = NativePluginRegistryBuilder::new();
+        builder
+            .register_plugin(Arc::new(TestPlugin))
+            .expect("register should succeed");
+        let registry = builder.build();
+
+        let filtered = registry
+            .filtered(|package_name| package_name == "test:plugin")
+            .expect("filter should succeed");
+
+        assert!(filtered.has_plugin("test:plugin"));
+        assert!(!filtered.has_plugin("test:other"));
     }
 }

--- a/crates/imagod-runtime/src/runner_process.rs
+++ b/crates/imagod-runtime/src/runner_process.rs
@@ -3,12 +3,14 @@
 //! The runner startup path decodes bootstrap metadata, registers with manager,
 //! starts inbound control handlers, and then executes component runtime flow.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 #[cfg(not(feature = "runtime-wasmtime"))]
 use async_trait::async_trait;
 use imago_protocol::ErrorCode;
-use imagod_common::ImagodError;
+use imagod_common::{
+    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS, ImagodError, is_builtin_native_plugin_package_name,
+};
 use imagod_ipc::{RunnerAppType, RunnerBootstrap};
 use imagod_runtime_bootstrap::{
     STAGE_RUNNER, SocketCleanupGuard, prepare_socket_path, read_runner_bootstrap,
@@ -319,6 +321,8 @@ fn create_runtime_backend(
 ) -> Result<Arc<RuntimeBackend>, ImagodError> {
     #[cfg(feature = "runtime-wasmtime")]
     {
+        let native_plugin_registry =
+            filter_registry_for_bootstrap(native_plugin_registry, bootstrap)?;
         let tuning = WasmEngineTuning {
             memory_reservation_bytes: bootstrap.wasm_memory_reservation_bytes,
             memory_reservation_for_growth_bytes: bootstrap.wasm_memory_reservation_for_growth_bytes,
@@ -327,7 +331,7 @@ fn create_runtime_backend(
             parallel_compilation: bootstrap.wasm_parallel_compilation,
         };
         Ok(Arc::new(WasmRuntime::new_with_native_plugins_and_tuning(
-            native_plugin_registry.clone(),
+            native_plugin_registry,
             tuning,
         )?))
     }
@@ -338,6 +342,31 @@ fn create_runtime_backend(
         let _ = bootstrap;
         Err(runtime_backend_unavailable_error())
     }
+}
+
+#[cfg(feature = "runtime-wasmtime")]
+fn filter_registry_for_bootstrap(
+    native_plugin_registry: &NativePluginRegistry,
+    bootstrap: &RunnerBootstrap,
+) -> Result<NativePluginRegistry, ImagodError> {
+    let enabled_native_plugins = if bootstrap.enabled_native_plugins.is_empty() {
+        BUILTIN_NATIVE_PLUGIN_DESCRIPTORS
+            .iter()
+            .filter(|descriptor| descriptor.default_enabled)
+            .map(|descriptor| descriptor.package_name)
+            .collect::<BTreeSet<_>>()
+    } else {
+        bootstrap
+            .enabled_native_plugins
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>()
+    };
+
+    native_plugin_registry.filtered(|package_name| {
+        !is_builtin_native_plugin_package_name(package_name)
+            || enabled_native_plugins.contains(package_name)
+    })
 }
 
 /// Observes run task during startup confirmation window.
@@ -431,7 +460,6 @@ mod tests {
     use super::*;
     use tokio::sync::oneshot;
 
-    #[cfg(not(feature = "runtime-wasmtime"))]
     fn sample_bootstrap() -> RunnerBootstrap {
         RunnerBootstrap {
             runner_id: "runner-a".to_string(),
@@ -451,6 +479,7 @@ mod tests {
             resources: std::collections::BTreeMap::new(),
             bindings: vec![],
             plugin_dependencies: vec![],
+            enabled_native_plugins: vec!["imago:admin".to_string(), "imago:node".to_string()],
             capabilities: imagod_ipc::CapabilityPolicy::default(),
             manager_control_endpoint: std::path::PathBuf::from("/tmp/manager.sock"),
             runner_endpoint: std::path::PathBuf::from("/tmp/runner.sock"),
@@ -480,6 +509,96 @@ mod tests {
             "unexpected message: {}",
             err.message
         );
+    }
+
+    #[cfg(feature = "runtime-wasmtime")]
+    #[test]
+    fn filter_registry_for_bootstrap_keeps_custom_plugins_and_enabled_builtins() {
+        use std::sync::Arc;
+
+        use imagod_runtime_wasmtime::native_plugins::{
+            NativePlugin, NativePluginLinker, NativePluginRegistryBuilder, NativePluginResult,
+        };
+
+        struct CustomPlugin;
+        struct AdminBuiltinPlugin;
+        struct UsbBuiltinPlugin;
+
+        impl NativePlugin for CustomPlugin {
+            fn package_name(&self) -> &'static str {
+                "test:custom"
+            }
+
+            fn supports_import(&self, import_name: &str) -> bool {
+                import_name == "test:custom/runtime@0.1.0"
+            }
+
+            fn symbols(&self) -> &'static [&'static str] {
+                &["test:custom/runtime@0.1.0.ping"]
+            }
+
+            fn add_to_linker(&self, _linker: &mut NativePluginLinker) -> NativePluginResult<()> {
+                Ok(())
+            }
+        }
+
+        impl NativePlugin for AdminBuiltinPlugin {
+            fn package_name(&self) -> &'static str {
+                "imago:admin"
+            }
+
+            fn supports_import(&self, import_name: &str) -> bool {
+                import_name == "imago:admin/runtime@0.1.0"
+            }
+
+            fn symbols(&self) -> &'static [&'static str] {
+                &["imago:admin/runtime@0.1.0.ping"]
+            }
+
+            fn add_to_linker(&self, _linker: &mut NativePluginLinker) -> NativePluginResult<()> {
+                Ok(())
+            }
+        }
+
+        impl NativePlugin for UsbBuiltinPlugin {
+            fn package_name(&self) -> &'static str {
+                "imago:usb"
+            }
+
+            fn supports_import(&self, import_name: &str) -> bool {
+                import_name == "imago:usb/runtime@0.1.0"
+            }
+
+            fn symbols(&self) -> &'static [&'static str] {
+                &["imago:usb/runtime@0.1.0.ping"]
+            }
+
+            fn add_to_linker(&self, _linker: &mut NativePluginLinker) -> NativePluginResult<()> {
+                Ok(())
+            }
+        }
+
+        let mut builder = NativePluginRegistryBuilder::new();
+        builder
+            .register_plugin(Arc::new(CustomPlugin))
+            .expect("custom plugin should register");
+        builder
+            .register_plugin(Arc::new(AdminBuiltinPlugin))
+            .expect("admin plugin should register");
+        builder
+            .register_plugin(Arc::new(UsbBuiltinPlugin))
+            .expect("usb plugin should register");
+        let registry = builder.build();
+
+        let mut bootstrap = sample_bootstrap();
+        bootstrap.enabled_native_plugins = vec!["imago:admin".to_string()];
+
+        let filtered =
+            filter_registry_for_bootstrap(&registry, &bootstrap).expect("filter should succeed");
+
+        assert!(filtered.has_plugin("test:custom"));
+        assert!(filtered.has_plugin("imago:admin"));
+        assert!(!filtered.has_plugin("imago:usb"));
     }
 
     #[test]

--- a/crates/imagod/src/lib.rs
+++ b/crates/imagod/src/lib.rs
@@ -9,6 +9,7 @@ use imago_plugin_imago_experimental_i2c::ImagoExperimentalI2cPlugin;
 use imago_plugin_imago_node::ImagoNodePlugin;
 use imago_plugin_imago_usb::ImagoUsbPlugin;
 use imago_protocol::PROTOCOL_VERSION;
+use imagod_common::BUILTIN_NATIVE_PLUGIN_DESCRIPTORS;
 use imagod_config::DEFAULT_CONTROL_SOCKET_PATH;
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -111,21 +112,9 @@ pub async fn dispatch_from_env_with_registry(
 pub fn register_builtin_native_plugins(
     builder: &mut NativePluginRegistryBuilder,
 ) -> Result<(), anyhow::Error> {
-    builder
-        .register_plugin(Arc::new(ImagoAdminPlugin))
-        .map_err(anyhow::Error::new)?;
-    builder
-        .register_plugin(Arc::new(ImagoNodePlugin))
-        .map_err(anyhow::Error::new)?;
-    builder
-        .register_plugin(Arc::new(ImagoExperimentalGpioPlugin))
-        .map_err(anyhow::Error::new)?;
-    builder
-        .register_plugin(Arc::new(ImagoExperimentalI2cPlugin))
-        .map_err(anyhow::Error::new)?;
-    builder
-        .register_plugin(Arc::new(ImagoUsbPlugin))
-        .map_err(anyhow::Error::new)?;
+    for descriptor in BUILTIN_NATIVE_PLUGIN_DESCRIPTORS {
+        register_builtin_native_plugin(builder, descriptor.package_name)?;
+    }
     Ok(())
 }
 
@@ -134,6 +123,37 @@ pub fn builtin_native_plugin_registry() -> Result<NativePluginRegistry, anyhow::
     let mut builder = NativePluginRegistryBuilder::new();
     register_builtin_native_plugins(&mut builder)?;
     Ok(builder.build())
+}
+
+fn register_builtin_native_plugin(
+    builder: &mut NativePluginRegistryBuilder,
+    package_name: &str,
+) -> Result<(), anyhow::Error> {
+    match package_name {
+        "imago:admin" => builder
+            .register_plugin(Arc::new(ImagoAdminPlugin))
+            .map_err(anyhow::Error::new)?,
+        "imago:node" => builder
+            .register_plugin(Arc::new(ImagoNodePlugin))
+            .map_err(anyhow::Error::new)?,
+        "imago:experimental-gpio" => builder
+            .register_plugin(Arc::new(ImagoExperimentalGpioPlugin))
+            .map_err(anyhow::Error::new)?,
+        "imago:experimental-i2c" => builder
+            .register_plugin(Arc::new(ImagoExperimentalI2cPlugin))
+            .map_err(anyhow::Error::new)?,
+        "imago:usb" => builder
+            .register_plugin(Arc::new(ImagoUsbPlugin))
+            .map_err(anyhow::Error::new)?,
+        other => {
+            return Err(anyhow::anyhow!(
+                "unsupported built-in native plugin package '{}'",
+                other
+            ));
+        }
+    };
+
+    Ok(())
 }
 
 fn install_rustls_provider() {
@@ -620,11 +640,31 @@ mod tests {
         #[test]
         fn builtin_registry_contains_default_plugins() {
             let registry = builtin_native_plugin_registry().expect("registry should build");
-            assert!(registry.has_plugin("imago:admin"));
-            assert!(registry.has_plugin("imago:node"));
-            assert!(registry.has_plugin("imago:experimental-gpio"));
-            assert!(registry.has_plugin("imago:experimental-i2c"));
-            assert!(registry.has_plugin("imago:usb"));
+            for descriptor in BUILTIN_NATIVE_PLUGIN_DESCRIPTORS {
+                assert!(
+                    registry.has_plugin(descriptor.package_name),
+                    "missing builtin plugin {}",
+                    descriptor.package_name
+                );
+            }
+        }
+
+        #[test]
+        fn builtin_registry_can_be_filtered_to_default_plugins() {
+            let registry = builtin_native_plugin_registry().expect("registry should build");
+            let filtered = registry
+                .filtered(|package_name| {
+                    BUILTIN_NATIVE_PLUGIN_DESCRIPTORS.iter().any(|descriptor| {
+                        descriptor.default_enabled && descriptor.package_name == package_name
+                    })
+                })
+                .expect("filtered registry should build");
+
+            assert!(filtered.has_plugin("imago:admin"));
+            assert!(filtered.has_plugin("imago:node"));
+            assert!(!filtered.has_plugin("imago:experimental-gpio"));
+            assert!(!filtered.has_plugin("imago:experimental-i2c"));
+            assert!(!filtered.has_plugin("imago:usb"));
         }
 
         #[test]
@@ -636,11 +676,13 @@ mod tests {
                 .register_plugin(Arc::new(TestPlugin))
                 .expect("custom plugin registration should work");
             let registry = builder.build();
-            assert!(registry.has_plugin("imago:admin"));
-            assert!(registry.has_plugin("imago:node"));
-            assert!(registry.has_plugin("imago:experimental-gpio"));
-            assert!(registry.has_plugin("imago:experimental-i2c"));
-            assert!(registry.has_plugin("imago:usb"));
+            for descriptor in BUILTIN_NATIVE_PLUGIN_DESCRIPTORS {
+                assert!(
+                    registry.has_plugin(descriptor.package_name),
+                    "missing builtin plugin {}",
+                    descriptor.package_name
+                );
+            }
             assert!(registry.has_plugin("test:custom"));
         }
 

--- a/crates/imagod/src/manager_runtime.rs
+++ b/crates/imagod/src/manager_runtime.rs
@@ -61,7 +61,12 @@ pub(crate) async fn run_manager(config_path: Option<PathBuf>) -> Result<(), anyh
         config.runtime.wasm_guard_before_linear_memory,
         config.runtime.wasm_parallel_compilation,
     )
-    .with_http_queue_memory_budget_bytes(config.runtime.http_queue_memory_budget_bytes);
+    .with_http_queue_memory_budget_bytes(config.runtime.http_queue_memory_budget_bytes)
+    .with_enabled_native_plugins(
+        config
+            .runtime
+            .effective_builtin_native_plugin_package_names(),
+    );
     let orchestrator = Orchestrator::new(&config.storage_root, artifacts.clone(), supervisor);
     let mut server = build_server(&config).map_err(anyhow::Error::new)?;
     #[cfg(unix)]

--- a/docs/imagod-configuration.md
+++ b/docs/imagod-configuration.md
@@ -156,6 +156,29 @@ known_public_keys = { "rpc://node-a:4443" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 This section controls transfer limits, worker settings, Wasmtime memory tuning, and startup behavior toggles.
 
+### The `features` field
+
+- Type: `boolean` or `array(string)`.
+- Required/Optional: Optional.
+- Accepted values / Constraints:
+  - `true`: enable all built-in native plugins shipped by `imagod`.
+  - `false` or `[]`: keep only the default built-in set (`imago:admin`, `imago:node`).
+  - `["imago:usb", "imago:experimental-gpio"]`: add named built-in plugins on top of the default set.
+  - Array items must be canonical built-in package names: `imago:admin`, `imago:node`, `imago:experimental-gpio`, `imago:experimental-i2c`, `imago:usb`.
+- Default: `false` (effective allowlist is `["imago:admin", "imago:node"]`).
+- Behavior notes:
+  - Arrays extend the default built-in set rather than replacing it.
+  - Custom plugins injected by embedding `imagod` are not configured through this field.
+  - Existing configs that rely on `imago:experimental-gpio`, `imago:experimental-i2c`, or `imago:usb` must now set `features = true` or add those package names explicitly.
+- Example:
+
+```toml
+[runtime]
+features = ["imago:usb"]
+```
+
+- Validation error notes: unknown package names or non-boolean / non-array values fail validation.
+
 ### The `chunk_size` field
 
 - Type: `integer` (`usize`)

--- a/examples/local-imagod-plugin-native-experimental-gpio/imagod.toml
+++ b/examples/local-imagod-plugin-native-experimental-gpio/imagod.toml
@@ -8,6 +8,7 @@ admin_public_keys = ["cd89018994ede35b4c80b21d7958a4a6fc2684637846f6938175b0a87c
 client_public_keys = ["c067e1cd0edd79ebd91e2bdb81c131ed601906af13c82c4e8f02ad6c4cfc5960"]
 
 [runtime]
+features = ["imago:experimental-gpio"]
 chunk_size = 1048576
 max_inflight_chunks = 16
 upload_session_ttl_secs = 900

--- a/examples/local-imagod-plugin-native-experimental-i2c/imagod.toml
+++ b/examples/local-imagod-plugin-native-experimental-i2c/imagod.toml
@@ -8,6 +8,7 @@ admin_public_keys = ["cd89018994ede35b4c80b21d7958a4a6fc2684637846f6938175b0a87c
 client_public_keys = ["c067e1cd0edd79ebd91e2bdb81c131ed601906af13c82c4e8f02ad6c4cfc5960"]
 
 [runtime]
+features = ["imago:experimental-i2c"]
 chunk_size = 1048576
 max_inflight_chunks = 16
 upload_session_ttl_secs = 900

--- a/schemas/imagod.schema.json
+++ b/schemas/imagod.schema.json
@@ -41,6 +41,30 @@
           "minimum": 0,
           "type": "integer"
         },
+        "features": {
+          "anyOf": [
+            {
+              "description": "true enables all built-in native plugins; false keeps only the default set",
+              "type": "boolean"
+            },
+            {
+              "description": "Additional built-in native plugin package names enabled beyond the default set",
+              "items": {
+                "enum": [
+                  "imago:admin",
+                  "imago:node",
+                  "imago:experimental-gpio",
+                  "imago:experimental-i2c",
+                  "imago:usb"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "default": false,
+          "description": "Built-in native plugin loading policy for runner startup."
+        },
         "http_queue_memory_budget_bytes": {
           "default": 33554432,
           "description": "Total memory budget for queued HTTP request bodies in bytes.",
@@ -247,6 +271,7 @@
         "committed_session_ttl_secs": 120,
         "deploy_stream_timeout_secs": 15,
         "epoch_tick_interval_ms": 50,
+        "features": false,
         "http_queue_memory_budget_bytes": 33554432,
         "http_worker_count": 2,
         "http_worker_queue_capacity": 4,


### PR DESCRIPTION
## Motivation
- `imagod` は builtin native plugin を常時リンクしていましたが、runtime ごとに必要な plugin は限られており、明示的な絞り込み手段がありませんでした。
- `imago:admin` / `imago:node` を default としたまま、`usb` や experimental plugin を明示 opt-in にしないと、不要な builtin plugin まで runtime に載る状態が続きます。

## Summary
- `imagod.toml` に `[runtime].features` を追加し、`true` / `false` / canonical builtin package 名の配列を受理する契約を `imagod-config`・schema・docs で同期しました。
- builtin native plugin descriptor を共有定義へ集約し、manager が effective allowlist を `RunnerBootstrap.enabled_native_plugins` で runner へ渡し、runner 側では builtin plugin だけを filter して custom plugin は保持するよう更新しました。
- defaults-only / all builtins / explicit additions / unknown reject の config tests、bootstrap validation、runner registry filter tests、schema assertions を追加し、experimental builtin を使う examples と `docs/imagod-configuration.md` を新契約へ合わせました。

## Validation
- `cargo test -p imagod-config -p imagod-ipc -p imagod-runtime -p imagod -p imago-schema-gen` ✅
- `cargo check --workspace` ✅
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false cargo test --workspace` ✅
  - local `commit.gpgsign=true` 環境では `tools/prup` の一時 repo commit test が署名待ちになるため、test 実行時だけ commit signing を無効化して完走を確認
