### PR TITLE
ci: add CodeQL advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+  schedule:
+    - cron: "19 18 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Match the current default setup extraction mode during the migration.
+          - language: actions
+            build-mode: none
+          - language: rust
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Motivation
- GitHub CodeQL default setup is emitting a pull-request warning that the `/language:rust` configuration from `main` was not found on PR heads.
- Move CodeQL configuration into the repository so the scan contract is versioned with the workflow and can be migrated off default setup cleanly.

## Summary
- Add `.github/workflows/codeql.yml` with a repo-managed CodeQL advanced setup workflow for `push`, `pull_request`, `schedule`, and `workflow_dispatch`.
- Analyze both `actions` and `rust` with `build-mode: none` to match the current default setup behavior during the migration.
- Set explicit concurrency and CodeQL permissions for the advanced setup workflow.
- Follow-up after merge: disable GitHub CodeQL default setup once this workflow is live on `main`.

## Validation
- `cargo fmt --all`: skipped because the only branch change is `.github/workflows/codeql.yml`, which does not affect Rust compile outputs.
- `cargo clippy --workspace --all-targets -- -D warnings`: skipped for the same reason.
- `cargo test --workspace`: skipped for the same reason.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codeql.yml"); puts "YAML OK"'`: passed.
- `actionlint .github/workflows/codeql.yml`: passed.
- `gh api repos/yieldspace/imago/code-scanning/default-setup`: confirmed the current default setup is configured for `actions` and `rust` before/after migration prep.