### PR TITLE
docs: redesign root README for onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,156 @@
 # imago
 
-Imago is a Wasm Component deployment and runtime platform for embedded Linux systems.
-It focuses on lightweight execution, explicit capability boundaries, and a predictable remote deploy workflow.
+imago is a Wasm Component deployment and runtime platform for embedded Linux systems.
+It is built for constrained environments where deployment needs to stay lightweight, capabilities must stay explicit, and remote operations need predictable control paths.
+The deployable unit is a Wasm Component, while `imagod` provides the daemon-side runtime and supervision boundary.
 
-Start with the documentation landing page:
+imago is under active development and is currently intended for private-network use.
 
-- [Documentation Home](docs/README.md)
+## What Is Imago?
 
-## Important Notice
+imago gives you a consistent path from project configuration to deployed Wasm service:
 
-imago is under development and currently intended for use on private networks.
+- Build a Wasm Component from an application project
+- Declare capabilities and target settings in config
+- Deploy to a local or remote `imagod`
+- Start, stop, inspect, and stream logs through the same control surface
 
-## Highlights
+If you want the shortest path to a running example, start with [QUICKSTART.md](QUICKSTART.md).
 
-- Wasm Component as the deployable unit
-- Capability-based permission model
-- Consistent deploy/run/stop workflow for local and remote targets
-- Embedded Linux oriented runtime footprint
+## Why imago
 
-## Quickstart
+- Lightweight runtime footprint for embedded Linux targets
+- Explicit capability boundaries instead of implicit host access
+- Predictable deploy and operate workflow through `imago` and `imagod`
+- Multiple execution models for one-shot, HTTP, socket, and RPC services
 
-See [QUICKSTART.md](QUICKSTART.md) for step-by-step setup and local example execution.
+## System Overview
 
-## Configuration References
+```mermaid
+flowchart LR
+    A["Developer project"] --> B["imago CLI"]
+    B -->|"build"| C["Wasm artifact + manifest"]
+    B -->|"deploy / logs / stop"| D["imagod"]
+    C --> D
+    D --> E["Runner process"]
+    E --> F["Wasm Component"]
+    F --> G["Plugin imports"]
+```
 
-- [imago.toml Reference](docs/imago-configuration.md)
-- [imagod.toml Reference](docs/imagod-configuration.md)
-- [Documentation Home](docs/README.md)
+The CLI is responsible for build, packaging, deployment requests, and operator-facing commands.
+`imagod` validates artifacts, manages lifecycle, and launches isolated runners for the component.
 
-## Source Of Truth (Code)
+## How Deployment Flows
 
-- Build and manifest normalization:
-  - [`crates/imago-cli/src/commands/build/mod.rs`](crates/imago-cli/src/commands/build/mod.rs)
-  - [`crates/imago-cli/src/commands/build/validation.rs`](crates/imago-cli/src/commands/build/validation.rs)
-- Dependency and lock resolution:
-  - [`crates/imago-cli/src/commands/update/mod.rs`](crates/imago-cli/src/commands/update/mod.rs)
-  - [`crates/imago-cli/src/lockfile/mod.rs`](crates/imago-cli/src/lockfile/mod.rs)
-- Wire contracts and validation:
-  - [`crates/imago-protocol/src/lib.rs`](crates/imago-protocol/src/lib.rs)
-  - [`crates/imago-protocol/src/messages`](crates/imago-protocol/src/messages)
-- Daemon runtime boundary:
-  - [`crates/imagod-server/src/protocol_handler.rs`](crates/imagod-server/src/protocol_handler.rs)
-  - [`crates/imagod-control/src/orchestrator.rs`](crates/imagod-control/src/orchestrator.rs)
-  - [`crates/imagod-control/src/service_supervisor.rs`](crates/imagod-control/src/service_supervisor.rs)
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant CLI as imago CLI
+    participant Daemon as imagod
+    participant Runner as Runner
 
-For generated API docs:
+    Dev->>CLI: Build project
+    CLI->>CLI: Validate config and produce manifest
+    Dev->>CLI: Deploy service
+    CLI->>Daemon: Upload manifest and artifact
+    Daemon->>Daemon: Verify digests and promote release
+    Daemon->>Runner: Start service
+    Runner-->>Daemon: Lifecycle events and logs
+    Daemon-->>CLI: Status and log stream
+    Dev->>CLI: Stop or inspect service
+```
+
+This keeps the operator workflow stable even when the target is remote: build locally, send a validated artifact set, then operate the service through the daemon boundary.
+
+## Execution Modes
+
+| Mode | Use case | Where to read more |
+| --- | --- | --- |
+| `cli` | One-shot command execution | [Architecture](docs/architecture.md) |
+| `http` | Long-running HTTP ingress service | [examples/local-imagod-http](examples/local-imagod-http/README.md) |
+| `socket` | Socket-oriented service with protocol constraints | [examples/local-imagod-socket](examples/local-imagod-socket/README.md) |
+| `rpc` | Resident service invoked through RPC calls | [Network RPC](docs/network-rpc.md) |
+
+## Quick Start Path
+
+Choose the path that matches what you want to do:
+
+### Start from a fresh template
+
+1. Install `imago` and `imagod`.
+   - Follow the installer and cargo options in [QUICKSTART.md](QUICKSTART.md).
+2. Create a new project and move into it.
+
+   ```bash
+   imago project init app --template rust
+   cd app
+   ```
+
+3. Continue with [QUICKSTART.md](QUICKSTART.md) for the remaining setup.
+   - It covers the `wasm32-wasip2` target, key generation, `imagod.toml`, daemon startup, and the first deploy.
+
+The bare `rust` template creates the application files only (`Cargo.toml`, `imago.toml`, and `src/main.rs`).
+It does not include `imagod.toml` or the TLS material needed to start `imagod`.
+
+### Try a checked-in sample
+
+For the shortest runnable path from this repository, use [examples/local-imagod/README.md](examples/local-imagod/README.md).
+
+```bash
+# Terminal 1
+cd examples/local-imagod
+cargo run -p imagod -- --config imagod.toml
+```
+
+```bash
+# Terminal 2
+cd examples/local-imagod
+# Run this after Terminal 1 has started imagod
+cargo run -p imago-cli -- service deploy --target default --detach
+cargo run -p imago-cli -- service logs local-imagod-app --tail 200
+```
+
+For more sample projects, browse [examples/README.md](examples/README.md).
+
+## Examples And Docs
+
+| Need | Start here |
+| --- | --- |
+| Documentation landing page | [docs/README.md](docs/README.md) |
+| High-level architecture | [docs/architecture.md](docs/architecture.md) |
+| Project config reference | [docs/imago-configuration.md](docs/imago-configuration.md) |
+| Daemon config reference | [docs/imagod-configuration.md](docs/imagod-configuration.md) |
+| RPC control path | [docs/network-rpc.md](docs/network-rpc.md) |
+| Runnable examples | [examples/README.md](examples/README.md) |
+
+## Repository Layout
+
+This repository is a Rust workspace with a few clear boundaries:
+
+| Path | Purpose |
+| --- | --- |
+| `crates/` | Core CLI, protocol, daemon, runtime, config, and support crates |
+| `plugins/` | Built-in plugin implementations and WIT packages |
+| `examples/` | Local example projects for common execution models and plugin usage |
+| `e2e/` | End-to-end test assets and scenarios |
+
+## Source Of Truth
+
+Normative behavior lives in the codebase and its tests, with user-facing explanations in `docs/`.
+Useful entry points:
+
+- Build and manifest rules: [`crates/imago-cli/src/commands/build/mod.rs`](crates/imago-cli/src/commands/build/mod.rs)
+- Dependency and lock resolution: [`crates/imago-cli/src/commands/update/mod.rs`](crates/imago-cli/src/commands/update/mod.rs)
+- Wire contracts: [`crates/imago-protocol/src/lib.rs`](crates/imago-protocol/src/lib.rs)
+- Daemon orchestration: [`crates/imagod-control/src/orchestrator.rs`](crates/imagod-control/src/orchestrator.rs)
+
+Generated API docs:
 
 ```bash
 cargo doc --workspace --no-deps
 ```
 
-## Development Checks
+## Development
 
 ```bash
 cargo fmt --all


### PR DESCRIPTION
## Motivation
- The root README was acting mostly as a link hub, which made first-time readers jump into multiple files before understanding what imago is and how it is operated.
- This change makes the repository landing page explain the platform, deploy flow, and first steps without duplicating the full quickstart and configuration references.

## Summary
- Redesign the root README into an onboarding-first landing page with a clearer platform overview and private-network notice.
- Add Mermaid diagrams for the system overview and deployment flow, plus an execution mode table, quick start path, docs/examples map, repository layout, and condensed source-of-truth guidance.
- Keep detailed setup and configuration in `QUICKSTART.md` and `docs/` so the root README stays high-level.

## Validation
- Rust preflight skipped because the changed file is non-Rust-impacting (`README.md` only).
- `git diff --check -- README.md`
  - Passed.
- `sh -c 'for f in QUICKSTART.md docs/README.md docs/architecture.md docs/imago-configuration.md docs/imagod-configuration.md docs/network-rpc.md examples/README.md examples/local-imagod-http/README.md examples/local-imagod-socket/README.md crates/imago-cli/src/commands/build/mod.rs crates/imago-cli/src/commands/update/mod.rs crates/imago-protocol/src/lib.rs crates/imagod-control/src/orchestrator.rs CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md; do [ -e "$f" ] || echo "missing:$f"; done'`
  - Passed; no missing link targets.
