### PR TITLE
fix: allow parent paths in imago.toml main

### DIFF
--- a/crates/imago-cli/src/commands/build/config_parse/validation.rs
+++ b/crates/imago-cli/src/commands/build/config_parse/validation.rs
@@ -170,6 +170,21 @@ pub(in crate::commands::build) fn normalize_relative_path(
     raw: &str,
     field_name: &str,
 ) -> anyhow::Result<PathBuf> {
+    normalize_relative_path_with_policy(raw, field_name, false)
+}
+
+pub(in crate::commands::build) fn normalize_source_main_path(
+    raw: &str,
+    field_name: &str,
+) -> anyhow::Result<PathBuf> {
+    normalize_relative_path_with_policy(raw, field_name, true)
+}
+
+fn normalize_relative_path_with_policy(
+    raw: &str,
+    field_name: &str,
+    allow_parent_dirs: bool,
+) -> anyhow::Result<PathBuf> {
     if raw.is_empty() {
         return Err(anyhow!("{field_name} must not be empty"));
     }
@@ -192,6 +207,7 @@ pub(in crate::commands::build) fn normalize_relative_path(
         match component {
             Component::CurDir => {}
             Component::Normal(segment) => normalized.push(segment),
+            Component::ParentDir if allow_parent_dirs => normalized.push(".."),
             Component::ParentDir | Component::RootDir => {
                 return Err(anyhow!(
                     "{field_name} must not contain path traversal: {raw}"
@@ -300,7 +316,12 @@ pub(in crate::commands::build) fn normalize_wasi_guest_path(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_relative_path, normalize_wasi_guest_path, validate_service_name};
+    use std::path::PathBuf;
+
+    use super::{
+        normalize_relative_path, normalize_source_main_path, normalize_wasi_guest_path,
+        validate_service_name,
+    };
 
     #[test]
     fn validate_service_name_rejects_unsupported_character() {
@@ -317,6 +338,35 @@ mod tests {
         let parent_err =
             normalize_relative_path("../file.wit", "field").expect_err("parent must fail");
         assert!(parent_err.to_string().contains("path traversal"));
+    }
+
+    #[test]
+    fn normalize_source_main_path_allows_parent_components_but_rejects_invalid_roots() {
+        assert_eq!(
+            normalize_source_main_path("../build/app.wasm", "main")
+                .expect("parent path should pass"),
+            PathBuf::from("../build/app.wasm")
+        );
+        assert_eq!(
+            normalize_source_main_path("./out/../app.wasm", "main")
+                .expect("dot segments should normalize"),
+            PathBuf::from("out/../app.wasm")
+        );
+
+        let empty_err = normalize_source_main_path("", "main").expect_err("empty path must fail");
+        assert!(empty_err.to_string().contains("must not be empty"));
+
+        let absolute_err = normalize_source_main_path("/tmp/app.wasm", "main")
+            .expect_err("absolute path must fail");
+        assert!(absolute_err.to_string().contains("relative path"));
+
+        let windows_err =
+            normalize_source_main_path("C:\\app.wasm", "main").expect_err("windows path must fail");
+        assert!(windows_err.to_string().contains("backslashes"));
+
+        let backslash_err = normalize_source_main_path("..\\app.wasm", "main")
+            .expect_err("backslash traversal must fail");
+        assert!(backslash_err.to_string().contains("backslashes"));
     }
 
     #[test]

--- a/crates/imago-cli/src/commands/build/mod.rs
+++ b/crates/imago-cli/src/commands/build/mod.rs
@@ -542,7 +542,7 @@ fn build_project_with_target_override_inner(
     validate_service_name(&name)?;
 
     let main_raw = required_string(&root, "main")?;
-    let source_main_path = normalize_relative_path(&main_raw, "main")?;
+    let source_main_path = normalize_source_main_path(&main_raw, "main")?;
 
     let app_type = required_string(&root, "type")?;
     validate_app_type(&app_type)?;
@@ -1181,6 +1181,43 @@ mod tests {
         assert!(root.join(&hashed_main).exists());
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn build_accepts_main_path_with_parent_segments() {
+        let workspace_root = new_temp_dir("main-parent-path");
+        let root = workspace_root.join("project");
+        fs::create_dir_all(&root).expect("project dir should be created");
+        write_imago_toml(
+            &root,
+            r#"
+    name = "svc"
+    main = "../shared/app.wasm"
+    type = "http"
+
+    [http]
+    port = 18080
+
+    [target.default]
+    remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+    "#,
+        );
+        write_file(&workspace_root.join("shared/app.wasm"), b"wasm-from-parent");
+
+        let output = build_project("default", &root).expect("build should succeed");
+        let manifest = read_manifest(&root, &output.manifest_path);
+        let hashed_main = assert_hashed_main_path(&manifest, "svc");
+        let hashed_main_path = root.join(&hashed_main);
+        assert!(
+            hashed_main_path.exists(),
+            "hashed main should be materialized"
+        );
+        assert_eq!(
+            fs::read(&hashed_main_path).expect("hashed main should be readable"),
+            b"wasm-from-parent"
+        );
+
+        let _ = fs::remove_dir_all(workspace_root);
     }
 
     #[test]

--- a/docs/imago-configuration.md
+++ b/docs/imago-configuration.md
@@ -48,9 +48,9 @@ name = "example-service"
 
 ### The `main` field
 
-- Type: `string` (relative file path)
+- Type: `string` (relative filesystem path)
 - Required/Optional: Required.
-- Accepted values / Constraints: non-empty; relative path only; no Windows drive prefix; no backslashes; no path traversal; file must exist.
+- Accepted values / Constraints: non-empty; relative path only; no Windows drive prefix; no backslashes; `.` segments are normalized away; `..` parent segments are allowed; file must exist.
 - Default: none.
 - Example:
 
@@ -58,7 +58,7 @@ name = "example-service"
 main = "build/app.wasm"
 ```
 
-- Validation error notes: missing file or unsafe path causes `imago artifact build` to fail.
+- Validation error notes: missing file or unsafe path syntax causes `imago artifact build` to fail. The build output rewrites `main` to a hashed artifact filename in `build/manifest.json`, so release manifests still use a traversal-free entry name.
 
 ### The `type` field
 


### PR DESCRIPTION
## Motivation
- `imago.toml` の `main` が `..` を含む source path を拒否しており、親ディレクトリの build output を参照できませんでした。
- build 入力だけを緩和しつつ、artifact manifest と deploy/runtime 側の path traversal 禁止は維持して柔軟性だけを増やします。

## Summary
- build の `main` 読み取りを `normalize_source_main_path` に分離し、相対 path の `..` を許可しました。
- 既存の strict `normalize_relative_path` は assets、dependency component、bundle entry に残し、deploy/runtime の traversal 拒否を維持しました。
- build テストと設定ドキュメントを更新し、親パスからの source wasm materialize と hashed `manifest.main` の維持を確認しました。

## Validation
- `cargo fmt --all`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo test --workspace`: passed