### PR TITLE
feat: add imago.toml name resolver support

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -88,7 +88,8 @@ Write the following content to `imago.toml` in your project root:
 ```toml
 "$schema" = "https://raw.githubusercontent.com/yieldspace/imago/main/schemas/imago.schema.json"
 
-name = "example-service"
+name.cargo = true
+
 main = "target/wasm32-wasip2/release/example-service.wasm"
 type = "cli"
 
@@ -113,6 +114,10 @@ remote = "ssh://root@your-host"
 
 You can also override the daemon control socket path with `remote = "ssh://root@your-host?socket=/run/imago/imagod.sock"`.
 SSH targets use the system `ssh` command and must not set `server_name` or `client_key`.
+
+`name.cargo = true` reads `./Cargo.toml` `[package].name` from the same project root as `imago.toml`.
+If you prefer a literal value, keep using `name = "example-service"` instead.
+This lookup does not search parent directories; a missing sibling file or missing `[package].name` fails closed.
 
 ## Configure `imagod.toml`
 

--- a/crates/imago-cli/src/commands/build/config_parse/dependency.rs
+++ b/crates/imago-cli/src/commands/build/config_parse/dependency.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::commands::build::LoadResolvedTomlOptions;
 
 pub(in crate::commands::build) fn parse_string_table(
     value: Option<&TomlValue>,
@@ -52,7 +53,13 @@ pub(crate) fn parse_namespace_registries(
 pub(crate) fn load_namespace_registries(
     project_root: &Path,
 ) -> anyhow::Result<plugin_sources::NamespaceRegistries> {
-    let root = load_resolved_toml(project_root, true)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: true,
+            resolve_service_name: true,
+        },
+    )?;
     parse_namespace_registries(root.get("namespace_registries"))
 }
 
@@ -60,7 +67,13 @@ pub(crate) fn load_project_dependencies_with_namespace_registries(
     project_root: &Path,
     namespace_registries: &plugin_sources::NamespaceRegistries,
 ) -> anyhow::Result<Vec<ProjectDependency>> {
-    let root = load_resolved_toml(project_root, true)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: true,
+            resolve_service_name: true,
+        },
+    )?;
     parse_project_dependencies(root.get("dependencies"), Some(namespace_registries))
 }
 
@@ -68,7 +81,13 @@ pub(crate) fn load_project_binding_sources_with_namespace_registries(
     project_root: &Path,
     namespace_registries: &plugin_sources::NamespaceRegistries,
 ) -> anyhow::Result<Vec<ProjectBindingSource>> {
-    let root = load_resolved_toml(project_root, true)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: true,
+            resolve_service_name: true,
+        },
+    )?;
     parse_project_binding_sources(root.get("bindings"), Some(namespace_registries))
 }
 

--- a/crates/imago-cli/src/commands/build/mod.rs
+++ b/crates/imago-cli/src/commands/build/mod.rs
@@ -18,7 +18,10 @@ use std::{
 };
 
 use anyhow::{Context, anyhow};
-use imago_project_config::{decode_document as decode_imago_toml_document, validate_for_build};
+use imago_project_config::{
+    ServiceNameField, ServiceNameResolver, decode_document as decode_imago_toml_document,
+    validate_for_build,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use toml::Value as TomlValue;
@@ -150,6 +153,12 @@ pub fn parse_target_remote(raw: &str) -> anyhow::Result<SshTargetRemote> {
         port: parsed.port(),
         socket_path,
     })
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(in crate::commands::build) struct LoadResolvedTomlOptions {
+    pub(in crate::commands::build) validate_build_contract: bool,
+    pub(in crate::commands::build) resolve_service_name: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -470,12 +479,24 @@ fn run_inner_with_target_override(
 }
 
 pub fn load_target_config(target_name: &str, project_root: &Path) -> anyhow::Result<TargetConfig> {
-    let root = load_resolved_toml(project_root, false)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: false,
+            resolve_service_name: false,
+        },
+    )?;
     parse_target(&root, target_name, project_root)
 }
 
 pub fn load_service_name(project_root: &Path) -> anyhow::Result<String> {
-    let root = load_resolved_toml(project_root, false)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: false,
+            resolve_service_name: true,
+        },
+    )?;
     let name = required_string(&root, "name")?;
     validate_service_name(&name)?;
     Ok(name)
@@ -533,7 +554,13 @@ fn build_project_with_target_override_inner(
     if emit_progress {
         ui::command_stage("artifact.build", "load-config", "loading imago.toml");
     }
-    let root = load_resolved_toml(project_root, true)?;
+    let root = load_resolved_toml(
+        project_root,
+        LoadResolvedTomlOptions {
+            validate_build_contract: true,
+            resolve_service_name: true,
+        },
+    )?;
     let namespace_registries = parse_namespace_registries(root.get("namespace_registries"))?;
 
     let command = parse_build_command(&root)?;
@@ -695,22 +722,130 @@ fn build_project_with_target_override_inner(
 
 fn load_resolved_toml(
     project_root: &Path,
-    validate_build_contract: bool,
+    options: LoadResolvedTomlOptions,
 ) -> anyhow::Result<toml::Table> {
     let path = project_root.join("imago.toml");
     let raw =
         fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
     let document = decode_imago_toml_document(&raw).context("failed to decode imago.toml")?;
-    if validate_build_contract {
+    if options.validate_build_contract {
         validate_for_build(&document)?;
     }
     let parsed: TomlValue = toml::from_str(&raw).context("failed to parse imago.toml")?;
-    let root = parsed
+    let mut root = parsed
         .as_table()
         .cloned()
         .ok_or_else(|| anyhow!("imago.toml root must be a table"))?;
+    if options.resolve_service_name {
+        resolve_service_name_field(&mut root, project_root, document.config.name.as_ref())?;
+    }
 
     Ok(root)
+}
+
+fn resolve_service_name_field(
+    root: &mut toml::Table,
+    project_root: &Path,
+    name_field: Option<&ServiceNameField>,
+) -> anyhow::Result<()> {
+    let Some(name_field) = name_field else {
+        return Ok(());
+    };
+
+    let resolved = match name_field {
+        ServiceNameField::Literal(_) => return Ok(()),
+        ServiceNameField::Resolver(resolver) => {
+            resolve_service_name_from_resolver(project_root, resolver)?
+        }
+    };
+
+    root.insert("name".to_string(), TomlValue::String(resolved));
+    Ok(())
+}
+
+fn resolve_service_name_from_resolver(
+    project_root: &Path,
+    resolver: &ServiceNameResolver,
+) -> anyhow::Result<String> {
+    match (resolver.cargo, resolver.pyproject) {
+        (true, false) => resolve_name_from_toml_path(
+            &project_root.join("Cargo.toml"),
+            "imago.toml key 'name.cargo'",
+            "package",
+            "name",
+        ),
+        (false, true) => resolve_name_from_toml_path(
+            &project_root.join("pyproject.toml"),
+            "imago.toml key 'name.pyproject'",
+            "project",
+            "name",
+        ),
+        _ => Err(anyhow!(
+            "imago.toml key 'name' must enable exactly one resolver: `cargo` or `pyproject`"
+        )),
+    }
+}
+
+fn resolve_name_from_toml_path(
+    path: &Path,
+    resolver_field: &str,
+    table_name: &str,
+    key_name: &str,
+) -> anyhow::Result<String> {
+    let raw = fs::read_to_string(path).with_context(|| {
+        format!(
+            "{resolver_field} requires readable sibling file {}",
+            path.display()
+        )
+    })?;
+    let parsed: TomlValue = toml::from_str(&raw).with_context(|| {
+        format!(
+            "{resolver_field} failed to parse sibling file {}",
+            path.display()
+        )
+    })?;
+    let root = parsed.as_table().ok_or_else(|| {
+        anyhow!(
+            "{resolver_field} requires {} to contain a TOML table root",
+            path.display()
+        )
+    })?;
+    let table = root
+        .get(table_name)
+        .and_then(TomlValue::as_table)
+        .ok_or_else(|| {
+            anyhow!(
+                "{resolver_field} requires sibling file {} to define [{}]",
+                path.display(),
+                table_name
+            )
+        })?;
+    let value = table.get(key_name).ok_or_else(|| {
+        anyhow!(
+            "{resolver_field} requires sibling file {} to define [{}].{}",
+            path.display(),
+            table_name,
+            key_name
+        )
+    })?;
+    let resolved = value.as_str().ok_or_else(|| {
+        anyhow!(
+            "{resolver_field} requires sibling file {} [{}].{} to be a string",
+            path.display(),
+            table_name,
+            key_name
+        )
+    })?;
+    let trimmed = resolved.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!(
+            "{resolver_field} resolved [{}].{} from {} to an empty string",
+            table_name,
+            key_name,
+            path.display()
+        ));
+    }
+    Ok(trimmed.to_string())
 }
 
 fn parse_restart_policy(root: &toml::Table) -> anyhow::Result<String> {
@@ -982,6 +1117,32 @@ mod tests {
             "remote = \"ssh://localhost?socket=/run/imago/imagod.sock\"",
         );
         write_file(&root.join("imago.toml"), body.as_bytes());
+    }
+
+    fn write_cargo_toml(root: &Path, package_name: &str) {
+        write_file(
+            &root.join("Cargo.toml"),
+            format!(
+                r#"[package]
+name = "{package_name}"
+version = "0.1.0"
+"#
+            )
+            .as_bytes(),
+        );
+    }
+
+    fn write_pyproject_toml(root: &Path, project_name: &str) {
+        write_file(
+            &root.join("pyproject.toml"),
+            format!(
+                r#"[project]
+name = "{project_name}"
+version = "0.1.0"
+"#
+            )
+            .as_bytes(),
+        );
     }
 
     fn write_imago_lock(root: &Path, lock: &ImagoLock) {
@@ -1826,6 +1987,169 @@ mod tests {
             err.to_string()
                 .contains("imago.toml missing required key: name")
         );
+        assert!(!root.join("build/side-effect.txt").exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolves_name_from_sibling_cargo_toml() {
+        let root = new_temp_dir("resolve-name-from-cargo");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+        write_cargo_toml(&root, "svc-from-cargo");
+        write_file(&root.join("build/app.wasm"), b"wasm-a");
+
+        let output = build_project("default", &root).expect("build should succeed");
+        let manifest = read_manifest(&root, &output.manifest_path);
+
+        assert_eq!(manifest.name, "svc-from-cargo");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn resolves_name_from_sibling_pyproject_toml() {
+        let root = new_temp_dir("resolve-name-from-pyproject");
+        write_imago_toml(
+            &root,
+            r#"
+    name.pyproject = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+        write_pyproject_toml(&root, "svc-from-pyproject");
+        write_file(&root.join("build/app.wasm"), b"wasm-a");
+
+        let output = build_project("default", &root).expect("build should succeed");
+        let manifest = read_manifest(&root, &output.manifest_path);
+
+        assert_eq!(manifest.name, "svc-from-pyproject");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn does_not_run_build_command_when_name_cargo_file_is_missing() {
+        let root = new_temp_dir("name-cargo-file-missing");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [build]
+    command = "mkdir -p build && printf side-effect > build/side-effect.txt"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+
+        let err = build_project("default", &root)
+            .expect_err("missing Cargo.toml should fail before build.command");
+        assert!(err.to_string().contains("name.cargo"));
+        assert!(err.to_string().contains("Cargo.toml"));
+        assert!(!root.join("build/side-effect.txt").exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn does_not_run_build_command_when_name_cargo_key_is_missing() {
+        let root = new_temp_dir("name-cargo-key-missing");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [build]
+    command = "mkdir -p build && printf side-effect > build/side-effect.txt"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+        write_file(
+            &root.join("Cargo.toml"),
+            br#"[package]
+version = "0.1.0"
+"#,
+        );
+
+        let err = build_project("default", &root)
+            .expect_err("missing [package].name should fail before build.command");
+        assert!(err.to_string().contains("[package].name"));
+        assert!(!root.join("build/side-effect.txt").exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn does_not_run_build_command_when_resolved_name_is_empty() {
+        let root = new_temp_dir("name-cargo-empty");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [build]
+    command = "mkdir -p build && printf side-effect > build/side-effect.txt"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+        write_cargo_toml(&root, "   ");
+
+        let err = build_project("default", &root)
+            .expect_err("empty resolved name should fail before build.command");
+        assert!(err.to_string().contains("empty string"));
+        assert!(!root.join("build/side-effect.txt").exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn does_not_run_build_command_when_resolved_name_is_invalid() {
+        let root = new_temp_dir("name-cargo-invalid");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [build]
+    command = "mkdir -p build && printf side-effect > build/side-effect.txt"
+
+    [target.default]
+    remote = "127.0.0.1:4443"
+    "#,
+        );
+        write_cargo_toml(&root, "svc/name");
+
+        let err = build_project("default", &root)
+            .expect_err("invalid resolved name should fail before build.command");
+        assert!(err.to_string().contains("invalid path characters"));
         assert!(!root.join("build/side-effect.txt").exists());
 
         let _ = fs::remove_dir_all(root);
@@ -4339,6 +4663,34 @@ mod tests {
     }
 
     #[test]
+    fn load_service_name_resolves_name_from_cargo_without_build_validation() {
+        let root = new_temp_dir("load-service-name-resolver");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [[dependencies]]
+    version = "0.1.0"
+    kind = "native"
+
+    [target.default]
+    remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+    "#,
+        );
+        write_cargo_toml(&root, "svc-from-cargo");
+
+        let default_name = load_service_name(&root)
+            .expect("load_service_name should resolve name without build validation");
+
+        assert_eq!(default_name, "svc-from-cargo");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn load_target_config_ignores_build_only_validation_errors() {
         let root = new_temp_dir("load-target-config-ignores-build-validation");
         write_imago_toml(
@@ -4359,6 +4711,58 @@ mod tests {
 
         let target = load_target_config("default", &root)
             .expect("load_target_config should not require build-only validation");
+
+        assert_eq!(
+            target.remote,
+            "ssh://localhost?socket=/run/imago/imagod.sock"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_target_config_ignores_missing_cargo_name_resolver_source() {
+        let root = new_temp_dir("load-target-config-missing-cargo-resolver-source");
+        write_imago_toml(
+            &root,
+            r#"
+    name.cargo = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [target.default]
+    remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+    "#,
+        );
+
+        let target = load_target_config("default", &root)
+            .expect("load_target_config should not resolve name.cargo");
+
+        assert_eq!(
+            target.remote,
+            "ssh://localhost?socket=/run/imago/imagod.sock"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn load_target_config_ignores_missing_pyproject_name_resolver_source() {
+        let root = new_temp_dir("load-target-config-missing-pyproject-resolver-source");
+        write_imago_toml(
+            &root,
+            r#"
+    name.pyproject = true
+    main = "build/app.wasm"
+    type = "cli"
+
+    [target.default]
+    remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+    "#,
+        );
+
+        let target = load_target_config("default", &root)
+            .expect("load_target_config should not resolve name.pyproject");
 
         assert_eq!(
             target.remote,

--- a/crates/imago-cli/templates/rust/imago.toml
+++ b/crates/imago-cli/templates/rust/imago.toml
@@ -1,6 +1,7 @@
 "$schema" = "https://raw.githubusercontent.com/yieldspace/imago/main/schemas/imago.schema.json"
 
-name = "example-service"
+name.cargo = true
+
 main = "target/release/wasm32-wasip2/example-service.wasm"
 type = "cli"
 

--- a/crates/imago-project-config/src/lib.rs
+++ b/crates/imago-project-config/src/lib.rs
@@ -1,10 +1,13 @@
 //! Typed configuration model for `imago.toml` plus JSON Schema derivation.
 
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use anyhow::{Result, anyhow};
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize,
+    de::{self, IntoDeserializer},
+};
 use serde_json::Value as JsonValue;
 use url::Url;
 
@@ -22,8 +25,8 @@ pub struct ImagoTomlDocument {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ImagoTomlConfig {
-    #[schemars(required)]
-    pub name: Option<String>,
+    #[schemars(with = "Option<ServiceNameFieldSchema>", required)]
+    pub name: Option<ServiceNameField>,
     #[schemars(required)]
     pub main: Option<String>,
     #[serde(rename = "type")]
@@ -53,6 +56,82 @@ pub enum AppType {
     Http,
     Socket,
     Rpc,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub enum ServiceNameField {
+    Literal(String),
+    Resolver(ServiceNameResolver),
+}
+
+#[derive(Debug, Clone, JsonSchema)]
+#[serde(untagged)]
+#[allow(dead_code)]
+enum ServiceNameFieldSchema {
+    Literal(String),
+    Resolver(ServiceNameResolver),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceNameResolver {
+    #[serde(default)]
+    pub cargo: bool,
+    #[serde(default)]
+    pub pyproject: bool,
+}
+
+impl<'de> Deserialize<'de> for ServiceNameField {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = toml::Value::deserialize(deserializer)?;
+        match value {
+            toml::Value::String(text) => Ok(Self::Literal(text)),
+            toml::Value::Table(table) => {
+                ServiceNameResolver::deserialize(toml::Value::Table(table).into_deserializer())
+                    .map(Self::Resolver)
+                    .map_err(de::Error::custom)
+            }
+            other => Err(de::Error::custom(format!(
+                "imago.toml key 'name' must be a string or table (got {other})"
+            ))),
+        }
+    }
+}
+
+impl JsonSchema for ServiceNameResolver {
+    fn inline_schema() -> bool {
+        false
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "ServiceNameResolver".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "type": "object",
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "required": ["cargo"],
+                    "properties": {
+                        "cargo": { "const": true },
+                        "pyproject": { "const": false, "default": false }
+                    }
+                },
+                {
+                    "required": ["pyproject"],
+                    "properties": {
+                        "cargo": { "const": false, "default": false },
+                        "pyproject": { "const": true }
+                    }
+                }
+            ]
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -234,6 +313,9 @@ pub fn decode_document(content: &str) -> Result<ImagoTomlDocument, toml::de::Err
 pub fn validate_for_build(document: &ImagoTomlDocument) -> Result<()> {
     let config = &document.config;
 
+    if let Some(name) = &config.name {
+        validate_name_field(name)?;
+    }
     if let Some(app_type) = &config.app_type {
         validate_allowed(
             app_type,
@@ -368,6 +450,31 @@ pub fn validate_for_build(document: &ImagoTomlDocument) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn validate_name_field(name: &ServiceNameField) -> Result<()> {
+    match name {
+        ServiceNameField::Literal(value) => {
+            if value.trim().is_empty() {
+                return Err(anyhow!("imago.toml key 'name' must not be empty"));
+            }
+        }
+        ServiceNameField::Resolver(resolver) => validate_name_resolver(resolver)?,
+    }
+    Ok(())
+}
+
+fn validate_name_resolver(resolver: &ServiceNameResolver) -> Result<()> {
+    let enabled_count = [resolver.cargo, resolver.pyproject]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
+    if enabled_count != 1 {
+        return Err(anyhow!(
+            "imago.toml key 'name' must enable exactly one resolver: `cargo` or `pyproject`"
+        ));
+    }
     Ok(())
 }
 
@@ -528,6 +635,118 @@ remote = "ssh://localhost?socket=/run/imago/imagod.sock"
 "#,
         );
         assert!(result.is_ok(), "unexpected error: {result:?}");
+    }
+
+    #[test]
+    fn accepts_name_cargo_resolver() {
+        let result = decode_and_validate(
+            r#"
+name.cargo = true
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        );
+        assert!(result.is_ok(), "unexpected error: {result:?}");
+    }
+
+    #[test]
+    fn accepts_name_pyproject_resolver() {
+        let result = decode_and_validate(
+            r#"
+name.pyproject = true
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        );
+        assert!(result.is_ok(), "unexpected error: {result:?}");
+    }
+
+    #[test]
+    fn rejects_name_resolver_without_enabled_source() {
+        let result = decode_and_validate(
+            r#"
+name = {}
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        );
+        let err = result.expect_err("validation must fail");
+        assert!(
+            err.to_string().contains("enable exactly one resolver"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_name_resolver_with_both_sources_enabled() {
+        let result = decode_and_validate(
+            r#"
+name = { cargo = true, pyproject = true }
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        );
+        let err = result.expect_err("validation must fail");
+        assert!(
+            err.to_string().contains("enable exactly one resolver"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_name_resolver_with_false_source() {
+        let result = decode_and_validate(
+            r#"
+name.cargo = false
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        );
+        let err = result.expect_err("validation must fail");
+        assert!(
+            err.to_string().contains("enable exactly one resolver"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_name_resolver_with_unknown_key() {
+        let err = decode_document(
+            r#"
+name.package_json = true
+
+main = "build/example-service.wasm"
+type = "cli"
+
+[target.default]
+remote = "ssh://localhost?socket=/run/imago/imagod.sock"
+"#,
+        )
+        .expect_err("decode must fail");
+        assert!(
+            err.to_string().contains("unknown field"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/imago-schema-gen/src/lib.rs
+++ b/crates/imago-schema-gen/src/lib.rs
@@ -111,10 +111,24 @@ mod tests {
             .get("properties")
             .and_then(JsonValue::as_object)
             .expect("imago root properties should be object");
+        let root_required = imago_json
+            .get("required")
+            .and_then(JsonValue::as_array)
+            .expect("imago root required should be array");
         let defs = imago_json
             .get("$defs")
             .and_then(JsonValue::as_object)
             .expect("imago $defs should be object");
+        let name_any_of = props
+            .get("name")
+            .and_then(|entry| entry.get("anyOf"))
+            .and_then(JsonValue::as_array)
+            .expect("imago name.anyOf should be array");
+        let name_resolver_one_of = defs
+            .get("ServiceNameResolver")
+            .and_then(|entry| entry.get("oneOf"))
+            .and_then(JsonValue::as_array)
+            .expect("ServiceNameResolver.oneOf should be array");
         let target_props = defs
             .get("TargetEntry")
             .and_then(|entry| entry.get("properties"))
@@ -184,6 +198,76 @@ mod tests {
         assert!(
             !props.contains_key("runtime"),
             "legacy runtime table must not be exposed in schema properties"
+        );
+        assert!(
+            root_required
+                .iter()
+                .any(|value| value.as_str() == Some("name")),
+            "name must be required in schema"
+        );
+        assert!(
+            name_any_of
+                .iter()
+                .any(|entry| entry.get("type").and_then(JsonValue::as_str) == Some("string")),
+            "name schema must allow literal strings"
+        );
+        assert!(
+            name_any_of.iter().any(|entry| {
+                entry.get("$ref").and_then(JsonValue::as_str) == Some("#/$defs/ServiceNameResolver")
+            }),
+            "name schema must allow resolver tables"
+        );
+        assert!(
+            name_resolver_one_of.len() == 2,
+            "resolver table must expose two exclusive branches"
+        );
+        assert!(
+            name_resolver_one_of.iter().any(|entry| {
+                entry
+                    .get("required")
+                    .and_then(JsonValue::as_array)
+                    .is_some_and(|required| {
+                        required.iter().any(|value| value.as_str() == Some("cargo"))
+                    })
+                    && entry
+                        .get("properties")
+                        .and_then(|value| value.get("cargo"))
+                        .and_then(|value| value.get("const"))
+                        .and_then(JsonValue::as_bool)
+                        == Some(true)
+                    && entry
+                        .get("properties")
+                        .and_then(|value| value.get("pyproject"))
+                        .and_then(|value| value.get("const"))
+                        .and_then(JsonValue::as_bool)
+                        == Some(false)
+            }),
+            "resolver table must require cargo=true in one branch"
+        );
+        assert!(
+            name_resolver_one_of.iter().any(|entry| {
+                entry
+                    .get("required")
+                    .and_then(JsonValue::as_array)
+                    .is_some_and(|required| {
+                        required
+                            .iter()
+                            .any(|value| value.as_str() == Some("pyproject"))
+                    })
+                    && entry
+                        .get("properties")
+                        .and_then(|value| value.get("cargo"))
+                        .and_then(|value| value.get("const"))
+                        .and_then(JsonValue::as_bool)
+                        == Some(false)
+                    && entry
+                        .get("properties")
+                        .and_then(|value| value.get("pyproject"))
+                        .and_then(|value| value.get("const"))
+                        .and_then(JsonValue::as_bool)
+                        == Some(true)
+            }),
+            "resolver table must require pyproject=true in one branch"
         );
         assert!(
             !target_props.contains_key("ca_cert"),

--- a/docs/imago-configuration.md
+++ b/docs/imago-configuration.md
@@ -34,9 +34,11 @@ These keys are read from the root TOML table and are not nested under a `[packag
 
 ### The `name` field
 
-- Type: `string`
+- Type: `string` or `table`
 - Required/Optional: Required.
-- Accepted values / Constraints: 1..=63 characters; ASCII `[A-Za-z0-9._-]` only; must not contain `/`, `\\`, or `..`.
+- Accepted values / Constraints:
+  - Literal string: 1..=63 characters; ASCII `[A-Za-z0-9._-]` only; must not contain `/`, `\\`, or `..`.
+  - Resolver table: enable exactly one of `cargo = true` or `pyproject = true`.
 - Default: none.
 - Example:
 
@@ -44,7 +46,19 @@ These keys are read from the root TOML table and are not nested under a `[packag
 name = "example-service"
 ```
 
-- Validation error notes: missing, empty, or invalid characters cause `imago artifact build` to fail.
+```toml
+name.cargo = true
+```
+
+```toml
+name.pyproject = true
+```
+
+- Resolution notes:
+  - `name.cargo = true` reads `Cargo.toml` `[package].name` from the same project root as `imago.toml`.
+  - `name.pyproject = true` reads `pyproject.toml` `[project].name` from the same project root as `imago.toml`.
+  - Resolver lookup is root-only and fail-closed. It does not search parent directories.
+- Validation error notes: missing, empty, invalid characters, missing sibling files, missing source keys, or invalid resolver tables cause `imago artifact build` to fail.
 
 ### The `main` field
 

--- a/schemas/imago.schema.json
+++ b/schemas/imago.schema.json
@@ -363,6 +363,40 @@
       ],
       "type": "string"
     },
+    "ServiceNameResolver": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "properties": {
+            "cargo": {
+              "const": true
+            },
+            "pyproject": {
+              "const": false,
+              "default": false
+            }
+          },
+          "required": [
+            "cargo"
+          ]
+        },
+        {
+          "properties": {
+            "cargo": {
+              "const": false,
+              "default": false
+            },
+            "pyproject": {
+              "const": true
+            }
+          },
+          "required": [
+            "pyproject"
+          ]
+        }
+      ],
+      "type": "object"
+    },
     "SocketSection": {
       "additionalProperties": true,
       "properties": {
@@ -483,7 +517,14 @@
       "type": "string"
     },
     "name": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/ServiceNameResolver"
+        }
+      ]
     },
     "namespace_registries": {
       "additionalProperties": {


### PR DESCRIPTION
## Reviewer Guides
- General review checklist: `.github/codex/labels/codex-review.md`
- Rust-specific checklist: `.github/codex/labels/codex-rust-review.md`

## Motivation
- `imago.toml` の service name を `Cargo.toml` や `pyproject.toml` と別管理すると、Rust / Python のサンプルや新規 project template で name drift が起きやすいです。
- root 直下の project metadata から fail-closed に解決できるようにして、二重入力を減らしつつ既存の literal `name` 指定は維持したい変更です。

## Summary
- `imago-project-config` で top-level `name` を literal string または `name.cargo = true` / `name.pyproject = true` の resolver に拡張し、schema と validation を同期しました。
- `imago-cli` の `load_resolved_toml()` に sibling `Cargo.toml` `[package].name` / `pyproject.toml` `[project].name` を読む解決フェーズを追加し、build や `load_service_name()` は解決済み name を使い、target 読み出しは不要な resolver 参照を避けるようにしました。
- resolver の成功系と fail-closed の回帰 test を追加し、Rust template、`QUICKSTART.md`、`docs/imago-configuration.md`、`schemas/imago.schema.json` を新契約に合わせて更新しました。

## Validation
- `cargo fmt --all`
  - Passed.
- `cargo clippy --workspace --all-targets -- -D warnings`
  - Passed.
- `cargo test --workspace`
  - Passed. Workspace unit/integration/doc tests completed successfully.
